### PR TITLE
Evento mapa cargado y limpieza tras compilar

### DIFF
--- a/mapea-js/Gruntfile.js
+++ b/mapea-js/Gruntfile.js
@@ -113,7 +113,14 @@ module.exports = function(grunt) {
             "build/plugins/<%= pkg.version %>/*.css",
             "build/plugins/<%= pkg.version %>/**/*.css",
             "!build/plugins/<%= pkg.version %>/**/*.min.css"
-         ]
+         ],
+         tasks: [
+               'grunt-tasks/utilities/exports/plugins/*.js',
+               'grunt-tasks/utilities/exports/*.js',
+               'grunt-tasks/utilities/symbols/plugins/*.json',
+               'grunt-tasks/utilities/symbols/*.json',
+               'src/externs/mapea-ol3x.js'
+            ]
       },
 
       cssmin: {
@@ -759,7 +766,7 @@ module.exports = function(grunt) {
    grunt.registerTask('dependencies-core', ['closure-dependencies:core']);
 
    // tasks
-   grunt.registerTask('build', ['clean-target', 'css-core', 'js-core', 'css-plugins', 'js-plugins', 'templates', 'dependencies-core' /*, 'test'*/ ]);
+   grunt.registerTask('build', ['clean-target', 'css-core', 'js-core', 'css-plugins', 'js-plugins', 'templates', 'dependencies-core' /*, 'test'*/, 'clean:tasks']);
    grunt.registerTask('test', ['mocha_phantomjs']);
    grunt.registerTask('dev', ['clean:dev', 'closure-dependencies:dev']);
 

--- a/mapea-js/src/externs/handlebarsx.js
+++ b/mapea-js/src/externs/handlebarsx.js
@@ -76,6 +76,20 @@ Compilerx.prototype.compiler;
  * @type {function}
  * @api stable
  */
+Compilerx.prototype.main;
+
+/**
+ * Property of Handlebars
+ * @type {function}
+ * @api stable
+ */
+Compilerx.prototype.useData;
+
+/**
+ * Property of Handlebars
+ * @type {function}
+ * @api stable
+ */
 Compilerx.prototype.equals;
 
 /**

--- a/mapea-js/src/facade/js/utils/template.js
+++ b/mapea-js/src/facade/js/utils/template.js
@@ -10,7 +10,7 @@ goog.require('M.exception');
  */
 (function(window) {
    /**
-    * This function stores the requested templates
+    * This object stores the requested templates
     * caching and reducing the code
     *
     * @private
@@ -86,6 +86,21 @@ goog.require('M.exception');
             });
          }
       }));
+   };
+
+   /**
+    * This function adds a precompiled template into the
+    * cached templates
+    *
+    * @function
+    * @param {string} templatePath name of the template
+    * @param {function} templateFn function of the precompiled template
+    * @api stable
+    */
+   M.template.add = function(templatePath, templateFn) {
+      if (M.utils.isUndefined(M.template.templates_[templatePath])) {
+         M.template.templates_[templatePath] = templateFn;
+      }
    };
 
    /**

--- a/mapea-js/src/impl/ol3/js/map/map.js
+++ b/mapea-js/src/impl/ol3/js/map/map.js
@@ -42,6 +42,7 @@ goog.require('ol.Map');
     * with the specified div
     *
     * @constructor
+    * @extends {M.Object}
     * @param {Object} div
     * @param {Mx.parameters.MapOptions} options
     * @api stable
@@ -104,6 +105,13 @@ goog.require('ol.Map');
        * @type {Mx.Extent}
        */
       this.userBbox_ = null;
+
+      /**
+       * TODO
+       * @private
+       * @type {Boolean}
+       */
+      this._calculatedResolutions = false;
 
       // gets the renderer
       var renderer = ol.RendererType.CANVAS;
@@ -1451,15 +1459,36 @@ goog.require('ol.Map');
          if (!M.utils.isNullOrEmpty(this.userMaxExtent_)) {
             resolutions = M.utils.generateResolutionsFromExtent(this.userMaxExtent_, size, zoomLevels, units);
             this.setResolutions(resolutions, true);
+            // checks if it was the first time to
+            // calculate resolutions in that case
+            // fires the completed event
+            if (this._calculatedResolutions === false) {
+               this._calculatedResolutions = true;
+               this.fire(M.evt.COMPLETED);
+            }
          }
          else if (!M.utils.isNullOrEmpty(minResolution) && !M.utils.isNullOrEmpty(maxResolution)) {
             resolutions = M.utils.fillResolutions(minResolution, maxResolution, zoomLevels);
             this.setResolutions(resolutions, true);
+            // checks if it was the first time to
+            // calculate resolutions in that case
+            // fires the completed event
+            if (this._calculatedResolutions === false) {
+               this._calculatedResolutions = true;
+               this.fire(M.evt.COMPLETED);
+            }
          }
          else {
             M.impl.envolvedExtent.calculate(this).then(function(extent) {
                resolutions = M.utils.generateResolutionsFromExtent(extent, size, zoomLevels, units);
                this.setResolutions(resolutions, true);
+               // checks if it was the first time to
+               // calculate resolutions in that case
+               // fires the completed event
+               if (this._calculatedResolutions === false) {
+                  this._calculatedResolutions = true;
+                  this.fire(M.evt.COMPLETED);
+               }
             }.bind(this));
          }
       }


### PR DESCRIPTION
## Cambios

- Disparar evento M.evt.COMPLETED cuando el mapa está cargado.
- Limpiar archivos intermedios de compilación tras ejecutar tarea Grunt.
- Se añade método a la API para añadir plantillas Handlebars en JS.