### PR TITLE
Interpretar HTML en popup de Geosearch

### DIFF
--- a/mapea-js/src/plugins/geosearch/templates/geosearchfeaturepopup.html
+++ b/mapea-js/src/plugins/geosearch/templates/geosearchfeaturepopup.html
@@ -1,15 +1,15 @@
 <div class="m-geosearch-content">
-   {{#each features}}
-   <div id="{{solrid}}" class="result">
-      {{#each attributes}}
-      <table>
-         <tr>
-            <td class="key">{{key}}</td>
-            <td class="value">{{value}}</td>
-         </tr>
-      </table>
-      {{/each}}
-   </div>
-   <div class="m-separator"></div>
-   {{/each}}
+    {{#each features}}
+    <div id="{{solrid}}" class="result">
+        {{#each attributes}}
+        <table>
+            <tr>
+                <td class="key">{{key}}</td>
+                <td class="value">{{{value}}}</td>
+            </tr>
+        </table>
+        {{/each}}
+    </div>
+    <div class="m-separator"></div>
+    {{/each}}
 </div>


### PR DESCRIPTION
## Cambios realizados

- Se actualiza la plantilla Handlebars del popup del plugin de Geosearch para que interprete contenido HTML (fixes #15)