### PR TITLE
Elimina capa KML correctamente a través del método removeKML

### DIFF
--- a/mapea-js/src/impl/ol3/js/map/map.js
+++ b/mapea-js/src/impl/ol3/js/map/map.js
@@ -458,6 +458,11 @@ goog.require('ol.Map');
       kmlMapLayers.forEach(function(kmlLayer) {
          this.layers_.remove(kmlLayer);
          kmlLayer.getImpl().destroy();
+         
+         // remove to featurehandler
+         if (kmlLayer.extract === true) {
+            this.featuresHandler_.removeLayer(kmlLayer.getImpl());
+         }
       }, this);
 
       return this;


### PR DESCRIPTION
## Cambios
- Se elimina la capa KML del featuresHandler cuando es eliminada a través del método removeKML (fixes #14)