### PR TITLE
Elimina popup KML cuando la capa KML es eliminada

### DIFF
--- a/mapea-js/src/impl/ol3/js/layers/kml.js
+++ b/mapea-js/src/impl/ol3/js/layers/kml.js
@@ -32,6 +32,13 @@ goog.require('goog.style');
       this.popup_ = null;
 
       /**
+       * Tab popup
+       * @private
+       * @type {Object}
+       */
+      this.tabPopup_ = null;
+
+      /**
        * Image tag for the screenOverlay
        * @private
        * @type {HTMLElement}
@@ -134,11 +141,12 @@ goog.require('goog.style');
             'parseToHtml': false
          }).then(function(htmlAsText) {
             this_.popup_ = new M.Popup();
-            this_.popup_.addTab({
+            this_.tabPopup_ = {
                'icon': 'g-cartografia-comentarios',
                'title': featureName,
                'content': htmlAsText
-            });
+            };
+            this_.popup_.addTab(this_.tabPopup_);
             this_.map.addPopup(this_.popup_, featureCoord);
          });
       }
@@ -186,8 +194,29 @@ goog.require('goog.style');
          olMap.removeLayer(this.ol3Layer);
          this.ol3Layer = null;
       }
+
+      this.removePopup();
+
       this.options = null;
       this.map = null;
+   };
+
+   /**
+    * This function destroys KML popup
+    *
+    * @public
+    * @function
+    * @api stable
+    */
+   M.impl.layer.KML.prototype.removePopup = function() {
+      if (!M.utils.isNullOrEmpty(this.popup_)) {
+         if (this.popup_.getTabs().length > 1) {
+            this.popup_.removeTab(this.tabPopup_);
+         }
+         else {
+            this.map.removePopup();
+         }
+      }
    };
 
    /**

--- a/mapea-js/src/impl/ol3/js/map/map.js
+++ b/mapea-js/src/impl/ol3/js/map/map.js
@@ -458,7 +458,6 @@ goog.require('ol.Map');
       kmlMapLayers.forEach(function(kmlLayer) {
          this.layers_.remove(kmlLayer);
          kmlLayer.getImpl().destroy();
-         this.facadeMap_.removePopup();
          
          // remove to featurehandler
          if (kmlLayer.extract === true) {

--- a/mapea-js/src/impl/ol3/js/map/map.js
+++ b/mapea-js/src/impl/ol3/js/map/map.js
@@ -458,6 +458,7 @@ goog.require('ol.Map');
       kmlMapLayers.forEach(function(kmlLayer) {
          this.layers_.remove(kmlLayer);
          kmlLayer.getImpl().destroy();
+         this.facadeMap_.removePopup();
          
          // remove to featurehandler
          if (kmlLayer.extract === true) {


### PR DESCRIPTION
## Cambios
- Eliminamos el popup o el tab correspondiente al eliminar la capa KML (fixes #14)