### PR TITLE
Resolución de incidencias detectadas en la 4.0.3.1

### DIFF
--- a/mapea-js/src/externs/mx.js
+++ b/mapea-js/src/externs/mx.js
@@ -834,6 +834,22 @@ Mx.parameters.GeoJSON.prototype.properties.vendor.mapea;
 Mx.parameters.GeoJSON.prototype.properties.vendor.mapea.icon;
 
 /**
+ * Object literal with config options for the Mapbox layer provided by the user.
+ * @typedef {{
+ *     accessToken: (String)
+ * }}
+ * @api
+ */
+Mx.parameters.Mapbox;
+
+/**
+ * Mapbox token API
+ * @type {String}
+ * @api stable
+ */
+Mx.parameters.Mapbox.prototype.accessToken;
+
+/**
  * Object literal with config options for the layer provided by the user.
  * @typedef {{
  *     type: (string),

--- a/mapea-js/src/facade/assets/css/mapea.css
+++ b/mapea-js/src/facade/assets/css/mapea.css
@@ -188,3 +188,27 @@ button::-moz-focus-inner {
       transform: rotate(360deg);
    }
 }
+
+
+/********************************/
+/* correcciones tamaño relativo */
+
+
+/*#map {
+	width: 600px !important;
+	height: 500px !important;
+}*/
+
+.ol-viewport, .ol-overlaycontainer-stopevent, .m-areas, .m-area.m-top.m-right{
+	height: inherit !important;
+}
+
+.m-panel.m-layerswitcher.opened{
+	height: calc(100% - 30px);
+}
+
+
+.m-areas> div.m-area> div.m-panel.m-layerswitcher> div.m-panel-controls{
+	height: 100% !important;
+	max-height: 100%;	
+}

--- a/mapea-js/src/facade/js/layers/layerbase.js
+++ b/mapea-js/src/facade/js/layers/layerbase.js
@@ -196,7 +196,7 @@ goog.require('M.parameter.layer');
          M.exception('La implementación usada no posee el método setVisible');
       }
 
-      visibility = /^true$/i.test(visibility);
+      visibility = /^1|(true)$/i.test(visibility);
 
       this.getImpl().setVisible(visibility);
    };

--- a/mapea-js/src/facade/js/layers/layertype.js
+++ b/mapea-js/src/facade/js/layers/layertype.js
@@ -75,7 +75,7 @@ goog.require('M.layer');
    * @public
    * @api stable
    */
-  M.layer.type.MAPBOX = 'Mapbox';
+  M.layer.type.Mapbox = 'Mapbox';
 
   /**
    * GeoJSON type
@@ -97,8 +97,14 @@ goog.require('M.layer');
     if (type === 'WMS_FULL') {
       type = M.layer.type.WMS;
     }
-    if (type === 'WFST') {
+    else if (type === 'WFST') {
       type = M.layer.type.WFS;
+    }
+    else {
+      type = Object.keys(M.layer.type).find(function (knowType) {
+        let knowTypeVal = M.layer.type[knowType];
+        return (M.utils.isString(knowTypeVal) && (M.utils.normalize(knowTypeVal, true) === type));
+      });
     }
     return M.layer.type[type];
   };

--- a/mapea-js/src/facade/js/layers/mapbox.js
+++ b/mapea-js/src/facade/js/layers/mapbox.js
@@ -36,7 +36,7 @@ goog.require('M.exception');
      */
     var impl = new M.impl.layer.Mapbox(userParameters, options);
 
-    var parameters = M.parameter.layer(userParameters, M.layer.type.MAPBOX);
+    var parameters = M.parameter.layer(userParameters, M.layer.type.Mapbox);
 
     // checks if the param is null or empty
     if (M.utils.isNullOrEmpty(parameters.name)) {
@@ -53,10 +53,69 @@ goog.require('M.exception');
       this.legend = parameters.name;
     }
 
+    // transparent
+    this.transparent = parameters.transparent;
+
+    // API Key token parameter
+    this.accessToken = parameters.accessToken;
+
     // options
     this.options = options;
   });
   goog.inherits(M.layer.Mapbox, M.Layer);
+
+  /**
+   * 'url' The service URL of the
+   * layer
+   */
+  Object.defineProperty(M.layer.Mapbox.prototype, "url", {
+    get: function () {
+      return this.getImpl().url;
+    },
+    // defining new type is not allowed
+    set: function (newUrl) {
+      if (!M.utils.isNullOrEmpty(newUrl)) {
+        this.getImpl().url = newUrl;
+      }
+      else {
+        this.getImpl().url = M.config.MAPBOX_URL;
+      }
+    }
+  });
+
+  /**
+   * 'tiled' the layer name
+   */
+  Object.defineProperty(M.layer.Mapbox.prototype, "transparent", {
+    get: function () {
+      return this.getImpl().transparent;
+    },
+    set: function (newTransparent) {
+      if (!M.utils.isNullOrEmpty(newTransparent)) {
+        this.getImpl().transparent = newTransparent;
+      }
+      else {
+        this.getImpl().transparent = false;
+      }
+    }
+  });
+
+  /**
+   * 'tiled' the layer name
+   */
+  Object.defineProperty(M.layer.Mapbox.prototype, "accessToken", {
+    get: function () {
+      return this.getImpl().accessToken;
+    },
+    set: function (newAccessToken) {
+      if (!M.utils.isNullOrEmpty(newAccessToken)) {
+        this.getImpl().accessToken = newAccessToken;
+      }
+      else {
+        this.getImpl().accessToken = M.config.MAPBOX_TOKEN_VALUE;
+      }
+    }
+  });
 
   /**
    * 'type' This property indicates if
@@ -64,13 +123,13 @@ goog.require('M.exception');
    */
   Object.defineProperty(M.layer.Mapbox.prototype, "type", {
     get: function () {
-      return M.layer.type.MAPBOX;
+      return M.layer.type.Mapbox;
     },
     // defining new type is not allowed
     set: function (newType) {
       if (!M.utils.isUndefined(newType) &&
-        !M.utils.isNullOrEmpty(newType) && (newType !== M.layer.type.MAPBOX)) {
-        M.exception('El tipo de capa debe ser \''.concat(M.layer.type.MAPBOX).concat('\' pero se ha especificado \'').concat(newType).concat('\''));
+        !M.utils.isNullOrEmpty(newType) && (newType !== M.layer.type.Mapbox)) {
+        M.exception('El tipo de capa debe ser \''.concat(M.layer.type.Mapbox).concat('\' pero se ha especificado \'').concat(newType).concat('\''));
       }
     }
   });

--- a/mapea-js/src/facade/js/layers/wfs.js
+++ b/mapea-js/src/facade/js/layers/wfs.js
@@ -17,7 +17,7 @@ goog.require('M.geom');
    * @param {Mx.parameters.LayerOptions} options provided by the user
    * @api stable
    */
-  M.layer.WFS = (function (userParameters, options) {
+  M.layer.WFS = (function (userParameters, options, implParam) {
     // checks if the implementation can create WFS layers
     if (M.utils.isUndefined(M.impl.layer.WFS)) {
       M.exception('La implementación usada no puede crear capas WFS');
@@ -35,7 +35,10 @@ goog.require('M.geom');
      * @public
      * @type {M.layer.WMS}
      */
-    var impl = new M.impl.layer.WFS(options);
+    var impl = implParam;
+    if (M.utils.isNullOrEmpty(impl)) {
+    	impl = new M.impl.layer.WFS(options);
+    }
 
     var parameters = M.parameter.layer(userParameters, M.layer.type.WFS);
 

--- a/mapea-js/src/facade/js/layers/wms.js
+++ b/mapea-js/src/facade/js/layers/wms.js
@@ -16,7 +16,7 @@ goog.require('M.exception');
      * @param {Mx.parameters.LayerOptions} options provided by the user
     * @api stable
     */
-   M.layer.WMS = (function(userParameters, options) {
+   M.layer.WMS = (function(userParameters, options, implParam) {
       // checks if the implementation can create WMC layers
       if (M.utils.isUndefined(M.impl.layer.WMS)) {
          M.exception('La implementación usada no puede crear capas WMS');
@@ -34,8 +34,11 @@ goog.require('M.exception');
        * @public
        * @type {M.layer.WMS}
        */
-      var impl = new M.impl.layer.WMS(options);
-
+      var impl = implParam;
+      if (M.utils.isNullOrEmpty(impl)) {
+         impl = new M.impl.layer.WMS(options);
+      }
+      
       var parameters = M.parameter.layer(userParameters, M.layer.type.WMS);
 
       // calls the super constructor

--- a/mapea-js/src/facade/js/parameters/center.js
+++ b/mapea-js/src/facade/js/parameters/center.js
@@ -37,7 +37,7 @@ goog.require('M.exception');
             else {
                M.exception('El formato del parámetro center no es correcto');
             }
-            center.draw = /^true$/i.test(draw);
+            center.draw = /^1|(true)$/i.test(draw);
          }
          else {
             M.exception('El formato del parámetro center no es correcto');

--- a/mapea-js/src/facade/js/parameters/layers.js
+++ b/mapea-js/src/facade/js/parameters/layers.js
@@ -73,7 +73,7 @@ goog.require('M.parameter.mapbox');
         type = M.layer.type.OSM;
       }
       else if (/^\s*mapbox\*.+$/i.test(parameter)) {
-        type = M.layer.type.MAPBOX;
+        type = M.layer.type.Mapbox;
       }
       else {
         var typeMatches = parameter.match(/^(\w+)\*.+$/);

--- a/mapea-js/src/facade/js/parameters/layers/kml.js
+++ b/mapea-js/src/facade/js/parameters/layers/kml.js
@@ -158,7 +158,7 @@ goog.require('M.exception');
       }
 
       if (!M.utils.isNullOrEmpty(extract)) {
-         extract = /^true$/i.test(extract);
+         extract = /^1|(true)$/i.test(extract);
       }
       else {
          extract = undefined;

--- a/mapea-js/src/facade/js/parameters/layers/mapbox.js
+++ b/mapea-js/src/facade/js/parameters/layers/mapbox.js
@@ -34,10 +34,19 @@ goog.require('M.exception');
       var layerObj = {};
 
       // gets the layer type
-      layerObj.type = M.layer.type.MAPBOX;
+      layerObj.type = M.layer.type.Mapbox;
+
+      // gets the name
+      layerObj.url = getURL(userParam);
 
       // gets the name
       layerObj.name = getName(userParam);
+
+      // gets the transparent
+      layerObj.transparent = getTransparent(userParam);
+
+      // gets the accessToken
+      layerObj.accessToken = getAccessToken(userParam);
 
       // gets the legend
       layerObj.legend = getLegend(userParam);
@@ -57,18 +66,56 @@ goog.require('M.exception');
    * @private
    * @function
    */
+  var getURL = function (parameter) {
+    var url;
+    if (M.utils.isString(parameter)) {
+      url = null; // URL by string type no supported
+    }
+    else if (M.utils.isObject(parameter) && !M.utils.isNullOrEmpty(parameter.url)) {
+      url = parameter.url.trim();
+    }
+    else if (!M.utils.isObject(parameter)) {
+      M.exception('El parámetro no es de un tipo soportado: ' + (typeof parameter));
+    }
+    return url;
+  };
+
+  /**
+   * Parses the parameter in order to get the layer name
+   * @private
+   * @function
+   */
+  var getAccessToken = function (parameter) {
+    var accessToken;
+    if (M.utils.isString(parameter)) {
+      accessToken = null; // accessToken by string type no supported
+    }
+    else if (M.utils.isObject(parameter) && !M.utils.isNullOrEmpty(parameter.accessToken)) {
+      accessToken = parameter.accessToken.trim();
+    }
+    else if (!M.utils.isObject(parameter)) {
+      M.exception('El parámetro no es de un tipo soportado: ' + (typeof parameter));
+    }
+    return accessToken;
+  };
+
+  /**
+   * Parses the parameter in order to get the layer name
+   * @private
+   * @function
+   */
   var getName = function (parameter) {
     var name, params;
     if (M.utils.isString(parameter)) {
       if (/^MAPBOX\*.+/i.test(parameter)) {
-        // <MAPBOX>*<NAME>(*<TITLE>)?
-        if (/^MAPBOX\*[^\*]+(\*[^\*]+)?/i.test(parameter)) {
+        // <MAPBOX>*<NAME>(*<TRANSPARENT>)?(*<TITLE>)?
+        if (/^MAPBOX\*[^\*]+(\*[^\*]+){0,2}/i.test(parameter)) {
           params = parameter.split(/\*/);
           name = params[1].trim();
         }
       }
-      // <NAME>(*<TITLE>)?
-      else if (/^[^\*]+(\*[^\*]+)?/.test(parameter)) {
+      // <NAME>(*<TRANSPARENT>)?(*<TITLE>)?
+      else if (/^[^\*]+(\*[^\*]+){0,2}/.test(parameter)) {
         params = parameter.split(/\*/);
         name = params[0].trim();
       }
@@ -87,6 +134,39 @@ goog.require('M.exception');
   };
 
   /**
+   * Parses the parameter in order to get the layer name
+   * @private
+   * @function
+   */
+  var getTransparent = function (parameter) {
+    var transparent, params;
+    if (M.utils.isString(parameter)) {
+      if (/^MAPBOX\*.+/i.test(parameter)) {
+        // <MAPBOX>*<NAME>*<TRANSPARENT>(*<TITLE>)?
+        if (/^MAPBOX\*[^\*]+\*[^\*]+(\*[^\*]+)?/i.test(parameter)) {
+          params = parameter.split(/\*/);
+          transparent = params[2].trim();
+        }
+      }
+      // <NAME>*<TRANSPARENT>(*<TITLE>)?
+      else if (/^[^\*]+\*[^\*]+(\*[^\*]+)?/.test(parameter)) {
+        params = parameter.split(/\*/);
+        transparent = params[1].trim();
+      }
+    }
+    else if (M.utils.isObject(parameter) && !M.utils.isNullOrEmpty(parameter.transparent)) {
+      transparent = M.utils.normalize(parameter.transparent);
+    }
+    else if (!M.utils.isObject(parameter)) {
+      M.exception('El parámetro no es de un tipo soportado: ' + (typeof parameter));
+    }
+    if (!M.utils.isNullOrEmpty(transparent)) {
+      transparent = /^1|(true)$/i.test(transparent);
+    }
+    return transparent;
+  };
+
+  /**
    * Parses the parameter in order to get the layer legend
    * @private
    * @function
@@ -95,16 +175,16 @@ goog.require('M.exception');
     var legend, params;
     if (M.utils.isString(parameter)) {
       if (/^MAPBOX\*.+/i.test(parameter)) {
-        // <MAPBOX>*<NAME>*<TITLE>
-        if (/^MAPBOX\*[^\*]+\*[^\*]+/i.test(parameter)) {
+        // <MAPBOX>*<NAME>*<TRANSPARENT>*<TITLE>
+        if (/^MAPBOX\*[^\*]+\*[^\*]+\*[^\*]+/i.test(parameter)) {
           params = parameter.split(/\*/);
-          legend = params[2].trim();
+          legend = params[3].trim();
         }
       }
-      // <NAME>*<TITLE>
-      else if (/^[^\*]+\*[^\*]+/.test(parameter)) {
+      // <NAME>*<TRANSPARENT>*<TITLE>
+      else if (/^[^\*]+\*[^\*]+\*[^\*]+/.test(parameter)) {
         params = parameter.split(/\*/);
-        legend = params[1].trim();
+        legend = params[2].trim();
       }
     }
     else if (M.utils.isObject(parameter) && !M.utils.isNullOrEmpty(parameter.legend)) {

--- a/mapea-js/src/facade/js/parameters/layers/wms.js
+++ b/mapea-js/src/facade/js/parameters/layers/wms.js
@@ -199,7 +199,7 @@ goog.require('M.exception');
          M.exception('El parámetro no es de un tipo soportado: ' + (typeof parameter));
       }
       if (!M.utils.isNullOrEmpty(transparent)) {
-         transparent = /^true$/i.test(transparent);
+         transparent = /^1|(true)$/i.test(transparent);
       }
       return transparent;
    };
@@ -241,7 +241,7 @@ goog.require('M.exception');
          M.exception('El parámetro no es de un tipo soportado: ' + (typeof parameter));
       }
       if (!M.utils.isNullOrEmpty(tiled)) {
-         tiled = /^true$/i.test(tiled);
+         tiled = /^1|(true)$/i.test(tiled);
       }
       return tiled;
    };

--- a/mapea-js/src/impl/ol3/js/format/wmc/wmc110.js
+++ b/mapea-js/src/impl/ol3/js/format/wmc/wmc110.js
@@ -74,7 +74,7 @@ M.impl.format.WMC.v110.prototype.getLayerFromInfo = function (layerInfo) {
     'name': layerInfo['name'],
     'legend': layerInfo['title'],
     'url': layerInfo['href'],
-    'transparent': !/^true$/i.test(options.isBaseLayer)
+    'transparent': !/^1|(true)$/i.test(options.isBaseLayer)
   }, options);
   return layer;
 };

--- a/mapea-js/src/impl/ol3/js/layers/osm.js
+++ b/mapea-js/src/impl/ol3/js/layers/osm.js
@@ -33,6 +33,8 @@ goog.require('ol.source.OSM');
 
     // calls the super constructor
     goog.base(this, options);
+
+    this.zIndex_ = M.impl.Map.Z_INDEX[M.layer.type.OSM];
   });
   goog.inherits(M.impl.layer.OSM, M.impl.Layer);
 
@@ -87,6 +89,9 @@ goog.require('ol.source.OSM');
     if (this.resolutions_ !== null) {
       this.setResolutions(this.resolutions_);
     }
+    // activates animation for base layers or animated parameters
+    let animated = (!this.options.animated || (this.options.animated === true));
+    this.ol3Layer.set("animated", animated);
   };
 
   /**

--- a/mapea-js/src/impl/ol3/js/layers/wfs.js
+++ b/mapea-js/src/impl/ol3/js/layers/wfs.js
@@ -103,11 +103,11 @@ goog.require('ol.source.Vector');
    *
    * @public
    * @function
-   * @param {M.Map} map
+   * @param {Boolean} forceNewSource
    * @api stable
    */
-  M.impl.layer.WFS.prototype.refresh = function () {
-    this.updateSource_();
+  M.impl.layer.WFS.prototype.refresh = function (forceNewSource) {
+    this.updateSource_(forceNewSource);
   };
 
   /**
@@ -116,7 +116,7 @@ goog.require('ol.source.Vector');
    * @private
    * @function
    */
-  M.impl.layer.WFS.prototype.updateSource_ = function () {
+  M.impl.layer.WFS.prototype.updateSource_ = function (forceNewSource) {
     var this_ = this;
 
     this.service_ = new M.impl.service.WFS({
@@ -129,7 +129,7 @@ goog.require('ol.source.Vector');
       'projection': this.map.getProjection(),
       'getFeatureOutputFormat': this.options.getFeatureOutputFormat,
       'describeFeatureTypeOutputFormat': this.options.describeFeatureTypeOutputFormat,
-    });
+    }, this.options.vendor);
     if (/json/gi.test(this.options.getFeatureOutputFormat)) {
       this.formater_ = new M.impl.format.GeoJSON({
         'defaultDataProjection': ol.proj.get(this.map.getProjection().code)
@@ -141,7 +141,7 @@ goog.require('ol.source.Vector');
     this.loader_ = new M.impl.loader.WFS(this.map, this.service_, this.formater_);
 
     var ol3LayerSource = this.ol3Layer.getSource();
-    if (M.utils.isNullOrEmpty(ol3LayerSource)) {
+    if ((forceNewSource === true) || M.utils.isNullOrEmpty(ol3LayerSource)) {
       this.ol3Layer.setSource(new ol.source.Vector({
         format: this.formater_,
         loader: this.loader_.getLoaderFn(function (features) {
@@ -158,6 +158,7 @@ goog.require('ol.source.Vector');
         this_.fire(M.evt.LOAD, [features]);
       }));
       ol3LayerSource.set("strategy", ol.loadingstrategy.all);
+      ol3LayerSource.changed();
     }
   };
 
@@ -171,7 +172,7 @@ goog.require('ol.source.Vector');
    */
   M.impl.layer.WFS.prototype.setCQL = function (newCQL) {
     this.cql = newCQL;
-    this.refresh();
+    this.refresh(true);
   };
 
   /**

--- a/mapea-js/src/impl/ol3/js/layers/wms.js
+++ b/mapea-js/src/impl/ol3/js/layers/wms.js
@@ -13,607 +13,608 @@ goog.require('ol.tilegrid.TileGrid');
 goog.require('ol.source.ImageWMS');
 goog.require('ol.extent');
 
-(function() {
-   /**
-    * @classdesc
-    * Main constructor of the class. Creates a WMS layer
-    * with parameters specified by the user
-    *
-    * @constructor
-    * @implements {M.impl.Layer}
-    * @param {Mx.parameters.LayerOptions} options custom options for this layer
-    * @api stable
-    */
-   M.impl.layer.WMS = (function(options) {
-      /**
-       * The WMS layers instances from capabilities
-       * @private
-       * @type {Array<M.layer.WMS>}
-       */
-      this.layers = [];
+(function () {
+  /**
+   * @classdesc
+   * Main constructor of the class. Creates a WMS layer
+   * with parameters specified by the user
+   *
+   * @constructor
+   * @implements {M.impl.Layer}
+   * @param {Mx.parameters.LayerOptions} options custom options for this layer
+   * @api stable
+   */
+  M.impl.layer.WMS = (function (options) {
+    /**
+     * The WMS layers instances from capabilities
+     * @private
+     * @type {Array<M.layer.WMS>}
+     */
+    this.layers = [];
 
-      /**
-       * WMS layer options
-       * @private
-        * @type {object}
-       * @expose
-       */
-      this.options = options || {};
+    /**
+     * WMS layer options
+     * @private
+     * @type {object}
+     * @expose
+     */
+    this.options = options || {};
 
-      /**
-       * WMS layer options
-       * @private
-       * @type {boolean}
-       * @expose
-       */
-      this.displayInLayerSwitcher = true;
+    /**
+     * WMS layer options
+     * @private
+     * @type {boolean}
+     * @expose
+     */
+    this.displayInLayerSwitcher = true;
 
-      /**
-       * get WMS getCapabilities promise
-       * @private
-       * @type {Promise}
-       */
-      this.getCapabilitiesPromise = null;
+    /**
+     * get WMS getCapabilities promise
+     * @private
+     * @type {Promise}
+     */
+    this.getCapabilitiesPromise = null;
 
-      /**
-       * get WMS extent promise
-       * @private
-       * @type {Promise}
-       */
-      this.extentPromise = null;
+    /**
+     * get WMS extent promise
+     * @private
+     * @type {Promise}
+     */
+    this.extentPromise = null;
 
-      /**
-       * Layer extent which was got from service getCapabilities
-       * @private
-       * @type {Mx.Extent}
-       */
-      this.extent = null;
+    /**
+     * Layer extent which was got from service getCapabilities
+     * @private
+     * @type {Mx.Extent}
+     */
+    this.extent = null;
 
-      /**
-       * Layer resolutions
-       * @private
-       * @type {Array<Number>}
-       */
-      this.resolutions_ = null;
+    /**
+     * Layer resolutions
+     * @private
+     * @type {Array<Number>}
+     */
+    this.resolutions_ = null;
 
-      /**
-       * Legend URL for this layer
-       * @private
-       * @type {string}
-       * @expose
-       */
-      this.legendUrl_ = null;
+    /**
+     * Legend URL for this layer
+     * @private
+     * @type {string}
+     * @expose
+     */
+    this.legendUrl_ = null;
 
-       /**
-       * Current projection
-       * @private
-       * @type {ol.Projection}
-       */
-      this.extentProj_ = null;
+    /**
+     * Current projection
+     * @private
+     * @type {ol.Projection}
+     */
+    this.extentProj_ = null;
 
-      // sets visibility
-      if (this.options.visibility === false) {
-         this.visibility = false;
+    // sets visibility
+    if (this.options.visibility === false) {
+      this.visibility = false;
+    }
+
+    // tiled
+    if (M.utils.isNullOrEmpty(this.tiled)) {
+      this.tiled = (this.options.singleTile !== true);
+    }
+
+    // number of zoom levels
+    if (M.utils.isNullOrEmpty(this.options.numZoomLevels)) {
+      this.options.numZoomLevels = 16; // by default
+    }
+
+    // animated
+    if (M.utils.isNullOrEmpty(this.options.animated)) {
+      this.options.animated = false; // by default
+    }
+
+    // calls the super constructor
+    goog.base(this, this.options);
+
+    this.zIndex_ = M.impl.Map.Z_INDEX[M.layer.type.WMS];
+  });
+  goog.inherits(M.impl.layer.WMS, M.impl.Layer);
+
+  /**
+   * This function sets the visibility of this layer
+   *
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.setVisible = function (visibility) {
+    this.visibility = visibility;
+    if (this.inRange() === true) {
+      // if this layer is base then it hides all base layers
+      if ((visibility === true) && (this.transparent !== true)) {
+        // hides all base layers
+        this.map.getBaseLayers().filter(function (layer) {
+          return (!layer.equals(this) && layer.isVisible());
+        }).forEach(function (layer) {
+          layer.setVisible(false);
+        });
+
+        // set this layer visible
+        if (!M.utils.isNullOrEmpty(this.ol3Layer)) {
+          this.ol3Layer.setVisible(visibility);
+        }
+
+        // updates resolutions and keep the bbox
+        var oldBbox = this.map.getBbox();
+        this.map.getImpl().updateResolutionsFromBaseLayer();
+        if (!M.utils.isNullOrEmpty(oldBbox)) {
+          this.map.setBbox(oldBbox);
+        }
       }
-
-      // tiled
-      if (M.utils.isNullOrEmpty(this.tiled)) {
-         this.tiled = (this.options.singleTile !== true);
+      else if (!M.utils.isNullOrEmpty(this.ol3Layer)) {
+        this.ol3Layer.setVisible(visibility);
       }
+    }
+  };
 
-      // number of zoom levels
-      if (M.utils.isNullOrEmpty(this.options.numZoomLevels)) {
-         this.options.numZoomLevels = 16; // by default
-      }
+  /**
+   * This function indicates if the layer is queryable
+   *
+   * @function
+   * @api stable
+   * @expose
+   */
+  M.impl.layer.WMS.prototype.isQueryable = function () {
+    return (this.options.queryable !== false);
+  };
 
-      // animated
-      if (M.utils.isNullOrEmpty(this.options.animated)) {
-         this.options.animated = false; // by default
-      }
+  /**
+   * This function sets the map object of the layer
+   *
+   * @public
+   * @function
+   * @param {M.impl.Map} map
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.addTo = function (map) {
+    this.map = map;
 
-      // calls the super constructor
-      goog.base(this, this.options);
+    // calculates the resolutions from scales
+    if (!M.utils.isNull(this.options) && !M.utils.isNull(this.options.minScale) && !M.utils.isNull(this.options.maxScale)) {
+      var units = this.map.getProjection().units;
+      this.options.minResolution = M.utils.getResolutionFromScale(this.options.minScale, units);
+      this.options.maxResolution = M.utils.getResolutionFromScale(this.options.maxScale, units);
+    }
 
-      this.zIndex_ = M.impl.Map.Z_INDEX[M.layer.type.WMS];
-   });
-   goog.inherits(M.impl.layer.WMS, M.impl.Layer);
+    // checks if it is a WMS_FULL
+    if (M.utils.isNullOrEmpty(this.name)) { // WMS_FULL (add all wms layers)
+      this.addAllLayers_();
+    }
+    else { // just one WMS layer
+      this.addSingleLayer_();
+    }
 
-   /**
-    * This function sets the visibility of this layer
-    *
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.setVisible = function(visibility) {
-      this.visibility = visibility;
-      if (this.inRange() === true) {
-         // if this layer is base then it hides all base layers
-         if ((visibility === true) && (this.transparent !== true)) {
-            // hides all base layers
-            this.map.getBaseLayers().filter(function(layer) {
-               return (!layer.equals(this) && layer.isVisible());
-            }).forEach(function(layer) {
-               layer.setVisible(false);
-            });
+    this.legendUrl_ = M.utils.addParameters(this.url, {
+      'SERVICE': "WMS",
+      'VERSION': this.version,
+      'REQUEST': "GetLegendGraphic",
+      'LAYER': this.name,
+      'FORMAT': "image/png",
+      'EXCEPTIONS': "image/png"
+    });
+  };
 
-            // set this layer visible
-            if (!M.utils.isNullOrEmpty(this.ol3Layer)) {
-               this.ol3Layer.setVisible(visibility);
-            }
+  /**
+   * This function sets the resolutions for this layer
+   *
+   * @public
+   * @function
+   * @param {Array<Number>} resolutions
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.setResolutions = function (resolutions) {
+    this.resolutions_ = resolutions;
 
-            // updates resolutions and bbox
-            this.getMaxExtent_().then(function(olExtent) {
-               this.map.getImpl().updateResolutionsFromBaseLayer();
-               this.map.setBbox(olExtent);
-            }.bind(this));
-         }
-         else if (!M.utils.isNullOrEmpty(this.ol3Layer)) {
-            this.ol3Layer.setVisible(visibility);
-         }
-      }
-   };
-
-   /**
-    * This function indicates if the layer is queryable
-    *
-    * @function
-    * @api stable
-    * @expose
-    */
-   M.impl.layer.WMS.prototype.isQueryable = function() {
-      return (this.options.queryable !== false);
-   };
-
-   /**
-    * This function sets the map object of the layer
-    *
-    * @public
-    * @function
-    * @param {M.impl.Map} map
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.addTo = function(map) {
-      this.map = map;
-
-      // calculates the resolutions from scales
-      if (!M.utils.isNull(this.options) && !M.utils.isNull(this.options.minScale) && !M.utils.isNull(this.options.maxScale)) {
-         var units = this.map.getProjection().units;
-         this.options.minResolution = M.utils.getResolutionFromScale(this.options.minScale, units);
-         this.options.maxResolution = M.utils.getResolutionFromScale(this.options.maxScale, units);
-      }
-
-      // checks if it is a WMS_FULL
-      if (M.utils.isNullOrEmpty(this.name)) { // WMS_FULL (add all wms layers)
-         this.addAllLayers_();
-      }
-      else { // just one WMS layer
-         this.addSingleLayer_();
-      }
-
-      this.legendUrl_ = M.utils.addParameters(this.url, {
-         'SERVICE': "WMS",
-         'VERSION': this.version,
-         'REQUEST': "GetLegendGraphic",
-         'LAYER': this.name,
-         'FORMAT': "image/png",
-         'EXCEPTIONS': "image/png"
-      });
-   };
-
-   /**
-    * This function sets the resolutions for this layer
-    *
-    * @public
-    * @function
-    * @param {Array<Number>} resolutions
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.setResolutions = function(resolutions) {
-      this.resolutions_ = resolutions;
-
-      if ((this.tiled === true) && !M.utils.isNullOrEmpty(this.ol3Layer)) {
-         // gets the extent
-         var this_ = this;
-         this.getMaxExtent_().then(function(olExtent) {
-            var layerParams = {};
-            var optParams = this_.options.params;
-            if (!M.utils.isNullOrEmpty(optParams)) {
-               for (var key in optParams) {
-                  if (optParams.hasOwnProperty(key)) {
-                     layerParams[key.toUpperCase()] = optParams[key];
-                  }
-               }
-               //TODO: parche para pedir todas las capas en PNG
-               // layerParams.FORMAT = "image/png";
-            }
-            else {
-               layerParams = {
-                  'LAYERS': this_.name,
-                  'TILED': true,
-                  'VERSION': this_.version,
-                  'TRANSPARENT': this_.transparent,
-                  'FORMAT': 'image/png'
-               };
-            }
-
-            var newSource;
-            if (this_.tiled === true) {
-               newSource = new ol.source.TileWMS({
-                  url: this_.url,
-                  params: layerParams,
-                  tileGrid: new ol.tilegrid.TileGrid({
-                     resolutions: resolutions,
-                     extent: olExtent,
-                     origin: ol.extent.getBottomLeft(olExtent)
-                  })
-               });
-            }
-            else {
-               newSource = new ol.source.ImageWMS({
-                  url: this_.url,
-                  params: layerParams,
-                  resolutions: resolutions
-               });
-            }
-            this_.ol3Layer.setSource(newSource);
-            this_.ol3Layer.setExtent(olExtent);
-         });
-      }
-   };
-
-   /**
-    * This function add this layer as unique layer
-    *
-    * @private
-    * @function
-    */
-   M.impl.layer.WMS.prototype.addSingleLayer_ = function() {
-      // gets resolutions of the map
-      var resolutions = this.map.getResolutions();
-
+    if ((this.tiled === true) && !M.utils.isNullOrEmpty(this.ol3Layer)) {
       // gets the extent
-      this.getMaxExtent_().then(function(olExtent) {
-         var tileGrid;
-
-         if (M.utils.isNullOrEmpty(resolutions) && !M.utils.isNullOrEmpty(this.resolutions_)) {
-            resolutions = this.resolutions_;
-         }
-
-         // gets the tileGrid
-         if (!M.utils.isNullOrEmpty(resolutions)) {
-            tileGrid = new ol.tilegrid.TileGrid({
-               resolutions: resolutions,
-               extent: olExtent,
-               origin: ol.extent.getBottomLeft(olExtent)
-            });
-         }
-
-         var layerParams = {};
-         var optParams = this.options.params;
-         if (!M.utils.isNullOrEmpty(optParams)) {
-            for (var key in optParams) {
-               if (optParams.hasOwnProperty(key)) {
-                  layerParams[key.toUpperCase()] = optParams[key];
-               }
+      var this_ = this;
+      this.getMaxExtent_().then(function (olExtent) {
+        var layerParams = {};
+        var optParams = this_.options.params;
+        if (!M.utils.isNullOrEmpty(optParams)) {
+          for (var key in optParams) {
+            if (optParams.hasOwnProperty(key)) {
+              layerParams[key.toUpperCase()] = optParams[key];
             }
-            //TODO: parche para pedir todas las capas en PNG
-            // layerParams.FORMAT = "image/png";
-         }
-         else {
-            layerParams = {
-               'LAYERS': this.name,
-               'TILED': true,
-               'VERSION': this.version,
-               'TRANSPARENT': this.transparent,
-               'FORMAT': 'image/png'
-            };
-         }
+          }
+          //TODO: parche para pedir todas las capas en PNG
+          // layerParams.FORMAT = "image/png";
+        }
+        else {
+          layerParams = {
+            'LAYERS': this_.name,
+            'TILED': true,
+            'VERSION': this_.version,
+            'TRANSPARENT': this_.transparent,
+            'FORMAT': 'image/png'
+          };
+        }
 
-         if (this.tiled === true) {
-            this.ol3Layer = new ol.layer.Tile({
-               visible: this.visibility,
-               source: new ol.source.TileWMS({
-                  url: this.url,
-                  params: layerParams,
-                  tileGrid: tileGrid
-               }),
-               extent: olExtent,
-               minResolution: this.options.minResolution,
-               maxResolution: this.options.maxResolution,
-               opacity: this.opacity_,
-               zIndex: this.zIndex_
-            });
-         }
-         else {
-            this.ol3Layer = new ol.layer.Image({
-               visible: this.options.visibility,
-               source: new ol.source.ImageWMS({
-                  url: this.url,
-                  params: layerParams
-               }),
-               extent: olExtent,
-               minResolution: this.options.minResolution,
-               maxResolution: this.options.maxResolution,
-               opacity: this.opacity_,
-               zIndex: this.zIndex_
-            });
-         }
-         // keeps z-index values before ol resets
-         let zIndex = this.zIndex_;
-         this.map.getMapImpl().addLayer(this.ol3Layer);
-         // sets its visibility if it is in range
-         if (this.isVisible() && !this.inRange()) {
-            this.setVisible(false);
-         }
-         // sets its z-index
-         if (zIndex !== null) {
-            this.setZIndex(zIndex);
-         }
-         // sets the resolutions
-         if (this.resolutions_ !== null) {
-            this.setResolutions(this.resolutions_);
-         }
-         // activates animation for base layers or animated parameters
-         let animated = ((this.transparent === false) || (this.options.animated === true));
-         this.ol3Layer.set("animated", animated);
-      }.bind(this));
-   };
+        var newSource;
+        if (this_.tiled === true) {
+          newSource = new ol.source.TileWMS({
+            url: this_.url,
+            params: layerParams,
+            tileGrid: new ol.tilegrid.TileGrid({
+              resolutions: resolutions,
+              extent: olExtent,
+              origin: ol.extent.getBottomLeft(olExtent)
+            })
+          });
+        }
+        else {
+          newSource = new ol.source.ImageWMS({
+            url: this_.url,
+            params: layerParams,
+            resolutions: resolutions
+          });
+        }
+        this_.ol3Layer.setSource(newSource);
+        this_.ol3Layer.setExtent(olExtent);
+      });
+    }
+  };
 
-   /**
-    * This function adds all layers defined int the server
-    *
-    * @private
-    * @function
-    */
-   M.impl.layer.WMS.prototype.addAllLayers_ = function() {
-      this.getCapabilities().then(function(getCapabilities) {
-         getCapabilities.getLayers().forEach(function(layer) {
-            var wmsLayer = new M.layer.WMS({
-               'url': this.url,
-               'name': layer.name,
-               'version': layer.version,
-               'tiled': this.tiled
-            }, this.options);
-            this.layers.push(wmsLayer);
-         }, this);
+  /**
+   * This function add this layer as unique layer
+   *
+   * @private
+   * @function
+   */
+  M.impl.layer.WMS.prototype.addSingleLayer_ = function () {
+    // gets resolutions of the map
+    var resolutions = this.map.getResolutions();
 
-         // if no base layers was specified then it stablishes
-         // the first layer as base
-         // if (this.map.getBaseLayers().length === 0) {
-         //    this.layers[0].transparent = false;
-         // }
+    // gets the extent
+    this.getMaxExtent_().then(function (olExtent) {
+      var tileGrid;
 
-         this.map.addWMS(this.layers);
-
-         // updates the z-index of the layers
-         var baseLayersIdx = this.layers.length;
-         this.layers.forEach(function(layer) {
-            layer.setZIndex(M.impl.Map.Z_INDEX[M.layer.type.WMS] + baseLayersIdx);
-            baseLayersIdx++;
-         });
-      }.bind(this));
-   };
-
-   /**
-    * This function gets the envolved extent for
-    * this WMS
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.getExtent = function() {
-      var olProjection = ol.proj.get(this.map.getProjection().code);
-
-      // creates the promise
-      this.extentPromise = new Promise(function(success, fail) {
-         if (!M.utils.isNullOrEmpty(this.extent_)) {
-            this.extent_ = ol.proj.transformExtent(this.extent_, this.extentProj_, olProjection);
-            this.extentProj_ = olProjection;
-            success(this.extent_);
-         }
-         else {
-            this.getCapabilities().then(function(getCapabilities) {
-               this.extent_ = getCapabilities.getLayerExtent(this.name);
-               this.extentProj_ = olProjection;
-               success(this.extent_);
-            }.bind(this));
-         }
-      }.bind(this));
-      return this.extentPromise;
-   };
-
-   /**
-    * This function gets the min resolution for
-    * this WMS
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.getMinResolution = function() {
-      return this.options.minResolution;
-   };
-
-   /**
-    * This function gets the max resolution for
-    * this WMS
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.getMaxResolution = function() {
-      return this.options.maxResolution;
-   };
-
-   /**
-    * Update minimum and maximum resolution WMS layers
-    *
-    * @public
-    * @function
-    * @param {ol.Projection} projection - Projection map
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.updateMinMaxResolution = function(projection) {
-      if (!M.utils.isNullOrEmpty(this.options.minResolution)) {
-         this.options.minResolution = M.utils.getResolutionFromScale(this.options.minScale, projection.units);
-         this.ol3Layer.setMinResolution(this.options.minResolution);
+      if (M.utils.isNullOrEmpty(resolutions) && !M.utils.isNullOrEmpty(this.resolutions_)) {
+        resolutions = this.resolutions_;
       }
 
-      if (!M.utils.isNullOrEmpty(this.options.maxResolution)) {
-         this.options.maxResolution = M.utils.getResolutionFromScale(this.options.maxScale, projection.units);
-         this.ol3Layer.setMaxResolution(this.options.maxResolution);
+      // gets the tileGrid
+      if (!M.utils.isNullOrEmpty(resolutions)) {
+        tileGrid = new ol.tilegrid.TileGrid({
+          resolutions: resolutions,
+          extent: olExtent,
+          origin: ol.extent.getBottomLeft(olExtent)
+        });
       }
-   };
 
-   /**
-    * This function gets the max resolution for
-    * this WMS
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.getNumZoomLevels = function() {
-      return this.options.numZoomLevels;
-   };
-
-   /**
-    * This function gets the layers loaded from this
-    * WMS FULL
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.getLayers = function() {
-      return this.layers;
-   };
-
-   /**
-    * This function destroys this layer, cleaning the HTML
-    * and unregistering all events
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.getCapabilities = function() {
-      // creates the promise
-      if (M.utils.isNullOrEmpty(this.getCapabilitiesPromise)) {
-         var layerUrl = this.url;
-         var layerVersion = this.version;
-         var projection = this.map.getProjection();
-         this.getCapabilitiesPromise = new Promise(function(success, fail) {
-            // gest the capabilities URL
-            var wmsGetCapabilitiesUrl = M.utils.getWMSGetCapabilitiesUrl(layerUrl, layerVersion);
-            // gets the getCapabilities response
-            M.remote.get(wmsGetCapabilitiesUrl).then(function(response) {
-               var getCapabilitiesDocument = response.xml;
-               var getCapabilitiesParser = new M.impl.format.WMSCapabilities();
-               var getCapabilities = getCapabilitiesParser.read(getCapabilitiesDocument);
-
-               var getCapabilitiesUtils = new M.impl.GetCapabilities(getCapabilities, layerUrl, projection);
-               success(getCapabilitiesUtils);
-            });
-         });
+      var layerParams = {};
+      var optParams = this.options.params;
+      if (!M.utils.isNullOrEmpty(optParams)) {
+        for (var key in optParams) {
+          if (optParams.hasOwnProperty(key)) {
+            layerParams[key.toUpperCase()] = optParams[key];
+          }
+        }
+        //TODO: parche para pedir todas las capas en PNG
+        // layerParams.FORMAT = "image/png";
       }
-      return this.getCapabilitiesPromise;
-   };
+      else {
+        layerParams = {
+          'LAYERS': this.name,
+          'TILED': true,
+          'VERSION': this.version,
+          'TRANSPARENT': this.transparent,
+          'FORMAT': 'image/png'
+        };
+      }
 
-   /**
-    * TODO
-    *
-    * @private
-    * @function
-    */
-   M.impl.layer.WMS.prototype.getMaxExtent_ = function() {
-      var extent = this.map.getMaxExtent();
-      return (new Promise(function(success, fail) {
-         if (!M.utils.isNullOrEmpty(extent)) {
-            if (!M.utils.isArray(extent)) {
-               extent = [extent.x.min, extent.y.min, extent.x.max, extent.y.max];
-            }
+      if (this.tiled === true) {
+        this.ol3Layer = new ol.layer.Tile({
+          visible: this.visibility && (this.options.visibility !== false),
+          source: new ol.source.TileWMS({
+            url: this.url,
+            params: layerParams,
+            tileGrid: tileGrid
+          }),
+          extent: olExtent,
+          minResolution: this.options.minResolution,
+          maxResolution: this.options.maxResolution,
+          opacity: this.opacity_,
+          zIndex: this.zIndex_
+        });
+      }
+      else {
+        this.ol3Layer = new ol.layer.Image({
+          visible: this.visibility && (this.options.visibility !== false),
+          source: new ol.source.ImageWMS({
+            url: this.url,
+            params: layerParams
+          }),
+          extent: olExtent,
+          minResolution: this.options.minResolution,
+          maxResolution: this.options.maxResolution,
+          opacity: this.opacity_,
+          zIndex: this.zIndex_
+        });
+      }
+      // keeps z-index values before ol resets
+      let zIndex = this.zIndex_;
+      this.map.getMapImpl().addLayer(this.ol3Layer);
+      // sets its visibility if it is in range
+      if (this.isVisible() && !this.inRange()) {
+        this.setVisible(false);
+      }
+      // sets its z-index
+      if (zIndex !== null) {
+        this.setZIndex(zIndex);
+      }
+      // sets the resolutions
+      if (this.resolutions_ !== null) {
+        this.setResolutions(this.resolutions_);
+      }
+      // activates animation for base layers or animated parameters
+      let animated = ((this.transparent === false) || (this.options.animated === true));
+      this.ol3Layer.set("animated", animated);
+    }.bind(this));
+  };
+
+  /**
+   * This function adds all layers defined int the server
+   *
+   * @private
+   * @function
+   */
+  M.impl.layer.WMS.prototype.addAllLayers_ = function () {
+    this.getCapabilities().then(function (getCapabilities) {
+      getCapabilities.getLayers().forEach(function (layer) {
+        var wmsLayer = new M.layer.WMS({
+          'url': this.url,
+          'name': layer.name,
+          'version': layer.version,
+          'tiled': this.tiled
+        }, this.options);
+        this.layers.push(wmsLayer);
+      }, this);
+
+      // if no base layers was specified then it stablishes
+      // the first layer as base
+      // if (this.map.getBaseLayers().length === 0) {
+      //    this.layers[0].transparent = false;
+      // }
+
+      this.map.addWMS(this.layers);
+
+      // updates the z-index of the layers
+      var baseLayersIdx = this.layers.length;
+      this.layers.forEach(function (layer) {
+        layer.setZIndex(M.impl.Map.Z_INDEX[M.layer.type.WMS] + baseLayersIdx);
+        baseLayersIdx++;
+      });
+    }.bind(this));
+  };
+
+  /**
+   * This function gets the envolved extent for
+   * this WMS
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.getExtent = function () {
+    var olProjection = ol.proj.get(this.map.getProjection().code);
+
+    // creates the promise
+    this.extentPromise = new Promise(function (success, fail) {
+      if (!M.utils.isNullOrEmpty(this.extent_)) {
+        this.extent_ = ol.proj.transformExtent(this.extent_, this.extentProj_, olProjection);
+        this.extentProj_ = olProjection;
+        success(this.extent_);
+      }
+      else {
+        this.getCapabilities().then(function (getCapabilities) {
+          this.extent_ = getCapabilities.getLayerExtent(this.name);
+          this.extentProj_ = olProjection;
+          success(this.extent_);
+        }.bind(this));
+      }
+    }.bind(this));
+    return this.extentPromise;
+  };
+
+  /**
+   * This function gets the min resolution for
+   * this WMS
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.getMinResolution = function () {
+    return this.options.minResolution;
+  };
+
+  /**
+   * This function gets the max resolution for
+   * this WMS
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.getMaxResolution = function () {
+    return this.options.maxResolution;
+  };
+
+  /**
+   * Update minimum and maximum resolution WMS layers
+   *
+   * @public
+   * @function
+   * @param {ol.Projection} projection - Projection map
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.updateMinMaxResolution = function (projection) {
+    if (!M.utils.isNullOrEmpty(this.options.minResolution)) {
+      this.options.minResolution = M.utils.getResolutionFromScale(this.options.minScale, projection.units);
+      this.ol3Layer.setMinResolution(this.options.minResolution);
+    }
+
+    if (!M.utils.isNullOrEmpty(this.options.maxResolution)) {
+      this.options.maxResolution = M.utils.getResolutionFromScale(this.options.maxScale, projection.units);
+      this.ol3Layer.setMaxResolution(this.options.maxResolution);
+    }
+  };
+
+  /**
+   * This function gets the max resolution for
+   * this WMS
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.getNumZoomLevels = function () {
+    return this.options.numZoomLevels;
+  };
+
+  /**
+   * This function gets the layers loaded from this
+   * WMS FULL
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.getLayers = function () {
+    return this.layers;
+  };
+
+  /**
+   * This function destroys this layer, cleaning the HTML
+   * and unregistering all events
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.getCapabilities = function () {
+    // creates the promise
+    if (M.utils.isNullOrEmpty(this.getCapabilitiesPromise)) {
+      var layerUrl = this.url;
+      var layerVersion = this.version;
+      var projection = this.map.getProjection();
+      this.getCapabilitiesPromise = new Promise(function (success, fail) {
+        // gest the capabilities URL
+        var wmsGetCapabilitiesUrl = M.utils.getWMSGetCapabilitiesUrl(layerUrl, layerVersion);
+        // gets the getCapabilities response
+        M.remote.get(wmsGetCapabilitiesUrl).then(function (response) {
+          var getCapabilitiesDocument = response.xml;
+          var getCapabilitiesParser = new M.impl.format.WMSCapabilities();
+          var getCapabilities = getCapabilitiesParser.read(getCapabilitiesDocument);
+
+          var getCapabilitiesUtils = new M.impl.GetCapabilities(getCapabilities, layerUrl, projection);
+          success(getCapabilitiesUtils);
+        });
+      });
+    }
+    return this.getCapabilitiesPromise;
+  };
+
+  /**
+   * TODO
+   *
+   * @private
+   * @function
+   */
+  M.impl.layer.WMS.prototype.getMaxExtent_ = function () {
+    var extent = this.map.getMaxExtent();
+    return (new Promise(function (success, fail) {
+      if (!M.utils.isNullOrEmpty(extent)) {
+        if (!M.utils.isArray(extent)) {
+          extent = [extent.x.min, extent.y.min, extent.x.max, extent.y.max];
+        }
+        success.call(this, extent);
+      }
+      else {
+        M.impl.envolvedExtent.calculate(this.map, this).then(function (extent) {
+          let maxExtent = this.map.getMaxExtent();
+          if (!M.utils.isNullOrEmpty(maxExtent)) {
+            success.call(this, maxExtent);
+          }
+          else {
             success.call(this, extent);
-         }
-         else {
-            M.impl.envolvedExtent.calculate(this.map, this).then(function(extent) {
-               let maxExtent = this.map.getMaxExtent();
-               if (!M.utils.isNullOrEmpty(maxExtent)) {
-                  success.call(this, maxExtent);
-               }
-               else {
-                  success.call(this, extent);
-               }
-            }.bind(this));
-         }
-      }.bind(this)));
-   };
-
-   /**
-    * This function destroys this layer, cleaning the HTML
-    * and unregistering all events
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.getLegendURL = function() {
-      return this.legendUrl_;
-   };
-
-   /**
-    * TODO
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.setLegendURL = function(legendUrl) {
-      this.legendUrl_ = legendUrl;
-   };
-
-   /**
-    * This function destroys this layer, cleaning the HTML
-    * and unregistering all events
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.destroy = function() {
-      var olMap = this.map.getMapImpl();
-      if (!M.utils.isNullOrEmpty(this.ol3Layer)) {
-         olMap.removeLayer(this.ol3Layer);
-         this.ol3Layer = null;
+          }
+        }.bind(this));
       }
-      if (!M.utils.isNullOrEmpty(this.layers)) {
-         this.layers.map(this.map.removeLayers, this.map);
-         this.layers.length = 0;
-      }
-      this.map = null;
-   };
+    }.bind(this)));
+  };
 
-   /**
-    * This function checks if an object is equals
-    * to this layer
-    *
-    * @function
-    * @api stable
-    */
-   M.impl.layer.WMS.prototype.equals = function(obj) {
-      var equals = false;
+  /**
+   * This function destroys this layer, cleaning the HTML
+   * and unregistering all events
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.getLegendURL = function () {
+    return this.legendUrl_;
+  };
 
-      if (obj instanceof M.impl.layer.WMS) {
-         equals = (this.url === obj.url);
-         equals = equals && (this.name === obj.name);
-         equals = equals && (this.cql === obj.cql);
-         equals = equals && (this.version === obj.version);
-      }
+  /**
+   * TODO
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.setLegendURL = function (legendUrl) {
+    this.legendUrl_ = legendUrl;
+  };
 
-      return equals;
-   };
+  /**
+   * This function destroys this layer, cleaning the HTML
+   * and unregistering all events
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.destroy = function () {
+    var olMap = this.map.getMapImpl();
+    if (!M.utils.isNullOrEmpty(this.ol3Layer)) {
+      olMap.removeLayer(this.ol3Layer);
+      this.ol3Layer = null;
+    }
+    if (!M.utils.isNullOrEmpty(this.layers)) {
+      this.layers.map(this.map.removeLayers, this.map);
+      this.layers.length = 0;
+    }
+    this.map = null;
+  };
 
-   M.impl.layer.WMS.LEGEND_IMAGE = null;
+  /**
+   * This function checks if an object is equals
+   * to this layer
+   *
+   * @function
+   * @api stable
+   */
+  M.impl.layer.WMS.prototype.equals = function (obj) {
+    var equals = false;
+
+    if (obj instanceof M.impl.layer.WMS) {
+      equals = (this.url === obj.url);
+      equals = equals && (this.name === obj.name);
+      equals = equals && (this.cql === obj.cql);
+      equals = equals && (this.version === obj.version);
+    }
+
+    return equals;
+  };
+
+  M.impl.layer.WMS.LEGEND_IMAGE = null;
 })();

--- a/mapea-js/src/impl/ol3/js/services/wfs.js
+++ b/mapea-js/src/impl/ol3/js/services/wfs.js
@@ -16,7 +16,7 @@ goog.require('M.exception');
    * @param {Mx.parameters.LayerOptions} options custom options for this layer
    * @api stable
    */
-  M.impl.service.WFS = (function (layerParameters) {
+  M.impl.service.WFS = (function (layerParameters, vendorOpts) {
 
     /**
      *
@@ -95,6 +95,28 @@ goog.require('M.exception');
      * @type {String}
      */
     this.describeFeatureTypeOutputFormat_ = layerParameters.describeFeatureTypeOutputFormat;
+
+    /**
+     * TODO
+     *
+     * @private
+     * @type {Object}
+     */
+    this.getFeatureVendor_ = {};
+    if (!M.utils.isNullOrEmpty(vendorOpts) && !M.utils.isNullOrEmpty(vendorOpts.getFeature)) {
+      this.getFeatureVendor_ = vendorOpts.getFeature;
+    }
+
+    /**
+     * TODO
+     *
+     * @private
+     * @type {Object}
+     */
+    this.describeFeatureTypeVendor_ = {};
+    if (!M.utils.isNullOrEmpty(vendorOpts) && !M.utils.isNullOrEmpty(vendorOpts.describeFeatureType)) {
+      this.describeFeatureTypeVendor_ = vendorOpts.describeFeatureType;
+    }
   });
 
   /**
@@ -117,7 +139,7 @@ goog.require('M.exception');
       describeFeatureParams['outputFormat'] = this.describeFeatureTypeOutputFormat_;
     }
 
-    var describeFeatureTypeUrl = M.utils.addParameters(this.url_, describeFeatureParams);
+    var describeFeatureTypeUrl = M.utils.addParameters(M.utils.addParameters(this.url_, describeFeatureParams), this.describeFeatureTypeVendor_);
     var describeFeatureTypeFormat = new M.impl.format.DescribeFeatureType(this.name_, this.describeFeatureTypeOutputFormat_, this.projection_);
     return new Promise(function (success, fail) {
       M.remote.get(describeFeatureTypeUrl).then(function (response) {
@@ -159,6 +181,6 @@ goog.require('M.exception');
       getFeatureParams['bbox'] = extent.join(',') + ',' + projection.getCode();
     }
 
-    return M.utils.addParameters(this.url_, getFeatureParams);
+    return M.utils.addParameters(M.utils.addParameters(this.url_, getFeatureParams), this.getFeatureVendor_);
   };
 })();

--- a/mapea-js/src/impl/ol3/js/source/mapboxsource.js
+++ b/mapea-js/src/impl/ol3/js/source/mapboxsource.js
@@ -16,23 +16,27 @@ goog.require('ol.source.OSM');
  */
 M.impl.source.Mapbox = function (opt_options) {
 
-  var options = opt_options || {};
+  /**
+   * Mapbox source options
+   * @private
+   * @type {object}
+   * @expose
+   */
+  this.options = opt_options || {};
 
   var attributions;
-  if (options.attributions !== undefined) {
-    attributions = options.attributions;
+  if (this.options.attributions !== undefined) {
+    attributions = this.options.attributions;
   }
   else {
     attributions = [M.impl.source.Mapbox.ATTRIBUTION];
   }
 
-  var url = options.url !== undefined ?
-    options.url : M.config.MAPBOX_URL;
-
-  url += options.name;
+  var url = this.options.url;
+  url += this.options.name;
   url += '/{z}/{x}/{y}.';
-  url += options.extension !== undefined ?
-    options.extension : M.config.MAPBOX_EXTENSION;
+  url += this.options.extension !== undefined ?
+    this.options.extension : M.config.MAPBOX_EXTENSION;
 
   // appends
   goog.base(this, {
@@ -50,12 +54,13 @@ goog.inherits(M.impl.source.Mapbox, ol.source.OSM);
  * @api stable
  */
 M.impl.source.Mapbox.prototype.setUrl = function (url) {
+  var accessToken = this.options.accessToken;
   let urlFunction = ol.TileUrlFunction.createFromTemplates(
     ol.TileUrlFunction.expandUrl(url), this.tileGrid);
   this.setTileUrlFunction(function () {
     let urlResolved = urlFunction.apply(this, arguments);
     let tokenParam = {};
-    tokenParam[M.config.MAPBOX_TOKEN_NAME] = M.config.MAPBOX_TOKEN_VALUE;
+    tokenParam[M.config.MAPBOX_TOKEN_NAME] = accessToken;
     return M.utils.addParameters(urlResolved, tokenParam);
   });
   this.urls = [url];

--- a/mapea-js/src/templates/geojson_popup.html
+++ b/mapea-js/src/templates/geojson_popup.html
@@ -5,7 +5,7 @@
       <table>
          <tr>
             <td class="key">{{key}}</td>
-            <td class="value">{{value}}</td>
+            <td class="value">{{{value}}}</td>
          </tr>
       </table>
       {{/each}}

--- a/mapea-parent/pom.xml
+++ b/mapea-parent/pom.xml
@@ -8,7 +8,7 @@
    <name>Mapea 4 PARENT</name>
    <description>Herramienta para desarrollo de mapas interactivos de forma sencilla</description>
    <properties>
-      <project.release.date>09/11/2016</project.release.date>
+      <project.release.date>28/12/2016</project.release.date>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <build.timestamp>${maven.build.timestamp}</build.timestamp>
       <maven.build.timestamp.format>dd-MM-yyyy</maven.build.timestamp.format>

--- a/mapea-parent/src/main/filters/mapea-local.properties
+++ b/mapea-parent/src/main/filters/mapea-local.properties
@@ -38,3 +38,8 @@ tile.mappings.urls=http://www.callejerodeandalucia.es/servicios/base/wms?,http:/
 controls=scale,scaleline,panzoombar,panzoom,layerswitcher,mouse,overviewmap,location
 services=WMS,WMS_FULL,KML,WFST,WMTS,MBtiles,OSM
 theme.names=default,dark,classic
+# mapbox configuration
+mapbox.url=https://api.mapbox.com/v4/
+mapbox.extension=png
+mapbox.token.name=access_token
+mapbox.token.value=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpbTgzcHQxMzAxMHp0eWx4bWQ1ZHN2NGcifQ.WVwjmljKYqKciEZIC3NfLA

--- a/mapea-rest/src/main/webapp/test/index.html
+++ b/mapea-rest/src/main/webapp/test/index.html
@@ -160,6 +160,10 @@
       <div class="prueba"><a target="_blank" href="../pruebaTicket.jsp"><b>CP-021-01</b><br/>Ticket</a></div>
       <div class="prueba"><a target="_blank" href="../?controls=navtoolbar,layerswitcher&wmcfile=callejero&layers=WMS_FULL*http://www.juntadeandalucia.es/medioambiente/mapwms/REDIAM_Permeabilidad_Andalucia?*false"><b>CP-022-01</b><br/>Parámetro layer (capa WMS-FULL sin tilear)</a></div>
       <div class="prueba"><a target="_blank" href="../?wmcfile=callejero&layers=WFS*CAPA_WFS*http://clientes.guadaltel.es/desarrollo/geossigc/wfs?*callejero:prueba_pol_wfst*MPOLYGON**cod_ine_municipio=%27001%27"><b>CP-023-01</b><br/>Layer WFS con filtrado CQL</a></div>
+      
+      <div class="prueba"><a target="_blank" href="../?controls=navtoolbar&layers=MAPBOX*mapbox.streets&zoom=6&center=235061.9,4141933.04*true&label=<b>Popup%20de%20prueba</b><br>Funciona%20correctamente%20con%20tildes:%20camión%20áéíóú"><b>CP-024-01</b><br/>Capa Mapbox base</a></div>
+      <div class="prueba"><a target="_blank" href="../?controls=navtoolbar,layerswitcher&wmcfile=callejero&layers=MAPBOX*mapbox.streets*true"><b>CP-024-02</b><br/>Capa Mapbox overlay</a></div>
+      <div class="prueba"><a target="_blank" href="../?controls=navtoolbar,layerswitcher&wmcfile=callejero&layers=MAPBOX*mapbox.emerald,MAPBOX*mapbox.comic*true"><b>CP-024-03</b><br/>WMC + Capa Mapbox base + Capa Mapbox overlay</a></div>
    </div>
    
    <div class="container">


### PR DESCRIPTION
## Resolución de incidencias de la 4.0.3.1

- Se establece un ZIndex a las capas Mapbox para que estén por encima de las capas base.
- Se añaden los parámetros: url, name, legend, transparent y accessToken al constructor de las capas Mapbox
- Se resuelve la incidencia setCQL para las capas WFS
- Se mantiene la vista en el cambio de capas base desde el layerswitcher