### PR TITLE
Versión 4.0.3 definitiva con corrección de errores

### DIFF
--- a/mapea-js/src/facade/js/eventsmanager.js
+++ b/mapea-js/src/facade/js/eventsmanager.js
@@ -167,6 +167,15 @@ goog.provide('M.evt.Listener');
 
   /**
    * Event type
+   * @public
+   * @type {string}
+   * @api stable
+   * @expose
+   */
+  M.evt.CHANGE_WMC = 'change:wmc';
+
+  /**
+   * Event type
    * @private
    * @type {array<string>}
    */
@@ -188,7 +197,8 @@ goog.provide('M.evt.Listener');
       M.evt.SELECT_FEATURES,
       M.evt.LOAD,
       M.evt.COMPLETED,
-      M.evt.CHANGE
+      M.evt.CHANGE,
+      M.evt.CHANGE_WMC
    ];
 
   /**

--- a/mapea-js/src/facade/js/map/map.js
+++ b/mapea-js/src/facade/js/map/map.js
@@ -234,6 +234,7 @@ goog.require('M.window');
         this.addControls(getFeatureInfo);
       }
     }
+
     // default WMC
     if (M.utils.isNullOrEmpty(params.wmc) && M.utils.isNullOrEmpty(params.layers)) {
       this.addWMC(M.config.predefinedWMC.predefinedNames[0]);
@@ -1332,7 +1333,9 @@ goog.require('M.window');
     if (controls.length > 0) {
       // removes controls from their panels
       controls.forEach(function (control) {
-        control.getPanel().removeControls(control);
+        if (!M.utils.isNullOrEmpty(control.getPanel())) {
+          control.getPanel().removeControls(control);
+        }
       }, this);
       // removes the controls
       this.getImpl().removeControls(controls);

--- a/mapea-js/src/impl/ol3/js/controls/getfeatureinfo.js
+++ b/mapea-js/src/impl/ol3/js/controls/getfeatureinfo.js
@@ -6,503 +6,503 @@ goog.require('ol.format.GML');
 /**
  * @namespace M.impl.control
  */
-(function() {
+(function () {
 
-   var regExs = {
-      gsResponse: /^results[\w\s\S]*\'http\:/i,
-      msNewFeature: /feature(\s*)(\w+)(\s*)\:/i,
-      gsNewFeature: /\#newfeature\#/,
-      gsGeometry: /geom$/i,
-      msGeometry: /boundedby$/i,
-      msUnsupportedFormat: /error(.*)unsupported(.*)info\_format/i
-   };
+  var regExs = {
+    gsResponse: /^results[\w\s\S]*\'http\:/i,
+    msNewFeature: /feature(\s*)(\w+)(\s*)\:/i,
+    gsNewFeature: /\#newfeature\#/,
+    gsGeometry: /geom$/i,
+    msGeometry: /boundedby$/i,
+    msUnsupportedFormat: /error(.*)unsupported(.*)info\_format/i
+  };
 
-   /**
-    * @classdesc
-    * Main constructor of the class. Creates a GetFeatureInfo
-    * control
-    *
-    * @constructor
-    * @param {string} format - Format response
-    * @param {Object} options - Control options
-    * @extends {M.impl.Control}
-    * @api stable
-    */
-   M.impl.control.GetFeatureInfo = function(format, options) {
-      /**
-       * Format response
-       * @public
-       * @type {String}
-       * @api stable
-       */
-      this.userFormat = format;
+  /**
+   * @classdesc
+   * Main constructor of the class. Creates a GetFeatureInfo
+   * control
+   *
+   * @constructor
+   * @param {string} format - Format response
+   * @param {Object} options - Control options
+   * @extends {M.impl.Control}
+   * @api stable
+   */
+  M.impl.control.GetFeatureInfo = function (format, options) {
+    /**
+     * Format response
+     * @public
+     * @type {String}
+     * @api stable
+     */
+    this.userFormat = format;
 
-      this.featureCount = options.featureCount;
-      if (M.utils.isNullOrEmpty(this.featureCount)) {
-         this.featureCount = 10;
+    this.featureCount = options.featureCount;
+    if (M.utils.isNullOrEmpty(this.featureCount)) {
+      this.featureCount = 10;
+    }
+
+    /**
+     * Buffer
+     * @public
+     * @type {Integer}
+     * @api stable
+     */
+    this.buffer = options.buffer;
+  };
+  goog.inherits(M.impl.control.GetFeatureInfo, M.impl.Control);
+
+  /**
+   * This function adds the event singleclick to the specified map
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.control.GetFeatureInfo.prototype.activate = function () {
+    this.addOnClickEvent_();
+  };
+
+  /**
+   * This function remove the event singleclick to the specified map
+   *
+   * @public
+   * @function
+   * @api stable
+   */
+  M.impl.control.GetFeatureInfo.prototype.deactivate = function () {
+    this.deleteOnClickEvent_();
+  };
+
+  /**
+   * This function adds the event singleclick to the specified map
+   *
+   * @private
+   * @function
+   */
+  M.impl.control.GetFeatureInfo.prototype.addOnClickEvent_ = function () {
+    var olMap = this.facadeMap_.getMapImpl();
+    if ((M.utils.normalize(this.userFormat) === "plain") || (M.utils.normalize(this.userFormat) === "text/plain")) {
+      this.userFormat = "text/plain";
+    }
+    else if ((M.utils.normalize(this.userFormat) === "gml") || (M.utils.normalize(this.userFormat) === "application/vnd.ogc.gml")) {
+      this.userFormat = "application/vnd.ogc.gml";
+    }
+    else {
+      this.userFormat = "text/html";
+    }
+    olMap.on('singleclick', this.buildUrl_, this);
+  };
+
+  /**
+   * This function builds the query URL and show results
+   *
+   * @private
+   * @function
+   * @param {ol.MapBrowserPointerEvent} evt - Browser point event
+   */
+  M.impl.control.GetFeatureInfo.prototype.buildUrl_ = function (evt) {
+    var olMap = this.facadeMap_.getMapImpl();
+    var viewResolution = olMap.getView().getResolution();
+    var srs = this.facadeMap_.getProjection().code;
+    var layerNamesUrls = [];
+    this.facadeMap_.getWMS().forEach(function (layer) {
+      var olLayer = layer.getImpl().getOL3Layer();
+      if (layer.isVisible() && layer.isQueryable() && !M.utils.isNullOrEmpty(olLayer)) {
+        let getFeatureInfoParams = {
+          'INFO_FORMAT': this.userFormat,
+          'FEATURE_COUNT': this.featureCount,
+        };
+        if (!/buffer/i.test(layer.url)) {
+          getFeatureInfoParams['Buffer'] = this.buffer;
+        }
+        var url = olLayer.getSource().getGetFeatureInfoUrl(evt.coordinate, viewResolution, srs, getFeatureInfoParams);
+        layerNamesUrls.push({
+          /** @type {String} */
+          'layer': layer.name,
+          /** @type {String} */
+          'url': url
+        });
       }
-      
-      /**
-       * Buffer
-       * @public
-       * @type {Integer}
-       * @api stable
-       */
-      this.buffer = options.buffer;
-   };
-   goog.inherits(M.impl.control.GetFeatureInfo, M.impl.Control);
+    }, this);
+    if (layerNamesUrls.length > 0) {
+      this.showInfoFromURL_(layerNamesUrls, evt.coordinate, olMap);
+    }
+    else {
+      M.dialog.info('No existen capas consultables');
+    }
+  };
 
-   /**
-    * This function adds the event singleclick to the specified map
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.control.GetFeatureInfo.prototype.activate = function() {
-      this.addOnClickEvent_();
-   };
+  /**
+   * This function remove the event singleclick to the specified map
+   *
+   * @private
+   * @function
+   */
+  M.impl.control.GetFeatureInfo.prototype.deleteOnClickEvent_ = function () {
+    var olMap = this.facadeMap_.getMapImpl();
+    olMap.un('singleclick', this.buildUrl_, this);
+  };
 
-   /**
-    * This function remove the event singleclick to the specified map
-    *
-    * @public
-    * @function
-    * @api stable
-    */
-   M.impl.control.GetFeatureInfo.prototype.deactivate = function() {
-      this.deleteOnClickEvent_();
-   };
+  /**
+   * This function specifies whether the information is valid
+   *
+   * @param {string} info - Information to validate
+   * @param {string} formato - Specific format to validate
+   * @returns {boolean} res - Is valid or not format
+   * @private
+   * @function
+   */
+  M.impl.control.GetFeatureInfo.prototype.insert_ = function (info, formato) {
+    var res = false;
+    switch (formato) {
+      case "text/html": // ex
+        var infoContainer = document.createElement("div");
+        infoContainer.innerHTML = info;
 
-   /**
-    * This function adds the event singleclick to the specified map
-    *
-    * @private
-    * @function
-    */
-   M.impl.control.GetFeatureInfo.prototype.addOnClickEvent_ = function() {
-      var olMap = this.facadeMap_.getMapImpl();
-      if ((M.utils.normalize(this.userFormat) === "plain") || (M.utils.normalize(this.userFormat) === "text/plain")) {
-         this.userFormat = "text/plain";
+        // content
+        var content = "";
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('body'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('div'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('table'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('b'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('span'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('input'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('a'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('img'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('p'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('ul'), function (element) {
+          content += element.innerHTML.trim();
+        });
+        Array.prototype.forEach.call(infoContainer.querySelectorAll('li'), function (element) {
+          content += element.innerHTML.trim();
+        });
+
+        if ((content.length > 0) && !/WMS\s+server\s+error/i.test(info)) {
+          res = true;
+        }
+        break;
+      case "application/vnd.ogc.gml": // ol.format.GML (http://openlayers.org/en/v3.9.0/apidoc/ol.format.GML.html)
+        var formater = new ol.format.WFS();
+        var features = formater.readFeatures(info);
+        res = (features.length > 0);
+        break;
+      case "text/plain": // exp reg
+        if (!/returned\s+no\s+results/i.test(info) && !/features\s+were\s+found/i.test(info) && !/:$/i.test(info)) {
+          res = true;
+        }
+        break;
+    }
+    return res;
+  };
+
+  /**
+   * This function formats the response
+   *
+   * @param {string} info - Information to formatting
+   * @param {string} formato - Specific format
+   * @param {string} layername - Layer name
+   * @returns {string} information - Formatted information
+   * @private
+   * @function
+   */
+  M.impl.control.GetFeatureInfo.prototype.formatInfo_ = function (info, formato, layerName) {
+    var formatedInfo = null;
+    switch (formato) {
+      case "text/html": // ex
+        formatedInfo = info;
+        break;
+      case "application/vnd.ogc.gml": // ol.format.GML (http://openlayers.org/en/v3.9.0/apidoc/ol.format.GML.html)
+        // var formater = new ol.format.GML();
+        // var feature = formater.readFeatures(info)[0];
+        var formater = new ol.format.WFS();
+        var features = formater.readFeatures(info);
+        formatedInfo = "";
+        features.forEach(function (feature) {
+          var attr = feature.getKeys();
+          formatedInfo += "<div class=\"divinfo\">";
+          formatedInfo += "<table class=\"mapea-table\"><tbody><tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
+          for (var i = 0, ilen = attr.length; i < ilen; i++) {
+            var attrName = attr[i];
+            var attrValue = feature.get(attrName);
+
+            formatedInfo += '<tr><td class="key"><b>';
+            formatedInfo += M.utils.beautifyAttribute(attrName);
+            formatedInfo += '</b></td><td class="value">';
+            formatedInfo += attrValue;
+            formatedInfo += "</td></tr>";
+          }
+          formatedInfo += "</tbody></table></div>";
+        });
+        break;
+      case "text/plain": // exp reg
+        if (regExs.gsResponse.test(info)) {
+          formatedInfo = this.txtToHtml_Geoserver_(info, layerName);
+        }
+        else {
+          formatedInfo = this.txtToHtml_Mapserver_(info, layerName);
+        }
+        break;
+    }
+    return formatedInfo;
+  };
+
+  /**
+   * This function indicates whether the format is accepted by the layer - Specific format text/html
+   *
+   * @param {string} info - Response to consult layer
+   * @param {string} formato - Specific format
+   * @returns {boolean} unsupported - It indicates whether the format is accepted
+   * @private
+   * @function
+   */
+  M.impl.control.GetFeatureInfo.prototype.unsupportedFormat_ = function (info, formato) {
+    var unsupported = false;
+    if (formato === "text/html") {
+      unsupported = regExs.msUnsupportedFormat.test(info);
+    }
+    return unsupported;
+  };
+
+  /**
+   * This function return formatted information. Specific Geoserver
+   *
+   * @private
+   * @function
+   * @param {string} info - Information to formatting
+   * @param {string} layername - Layer name
+   * @returns {string} html - Information formated
+   */
+  M.impl.control.GetFeatureInfo.prototype.txtToHtml_Geoserver_ = function (info, layerName) {
+    // get layer name from the header
+    // var layerName = info.replace(/[\w\s\S]*\:(\w*)\'\:[\s\S\w]*/i, "$1");
+
+    // remove header
+    info = info.replace(/[\w\s\S]*\'\:/i, "");
+
+    info = info.replace(/---(\-*)(\n+)---(\-*)/g, "#newfeature#");
+
+    var attrValuesString = info.split("\n");
+
+    var html = "<div class=\"divinfo\">";
+
+    // build the table
+    html += "<table class=\"mapea-table\"><tbody><tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
+
+    for (var i = 0, ilen = attrValuesString.length; i < ilen; i++) {
+      var attrValueString = attrValuesString[i].trim();
+      if (attrValueString.indexOf("=") != -1) {
+        var attrValue = attrValueString.split("=");
+        var attr = attrValue[0].trim();
+        var value = "-";
+        if (attrValue.length > 1) {
+          value = attrValue[1].trim();
+          if (value.length === 0 || value === "null") {
+            value = "-";
+          }
+        }
+
+        if (regExs.gsGeometry.test(attr) === false) {
+          html += '<tr><td class="key"><b>';
+          html += M.utils.beautifyAttribute(attr);
+          html += '</b></td><td class="value">';
+          html += value;
+          html += "</td></tr>";
+        }
       }
-      else if ((M.utils.normalize(this.userFormat) === "gml") || (M.utils.normalize(this.userFormat) === "application/vnd.ogc.gml")) {
-         this.userFormat = "application/vnd.ogc.gml";
+      else if (regExs.gsNewFeature.test(attrValueString)) {
+        // set new header
+        html += "<tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
       }
-      else {
-         this.userFormat = "text/html";
+    }
+
+    html += "</tbody></table></div>";
+
+    return html;
+  };
+
+  /**
+   * This function return formatted information. Specific Mapserver
+   *
+   * @private
+   * @function
+   * @param {string} info - Information to formatting
+   * @returns {string} html - Information formated
+   */
+  M.impl.control.GetFeatureInfo.prototype.txtToHtml_Mapserver_ = function (info) {
+    // remove header
+    info = info.replace(/[\w\s\S]*(layer)/i, "$1");
+
+    // get layer name
+    var layerName = info.replace(/layer(\s*)\'(\w+)\'[\w\s\S]*/i, "$2");
+
+    // remove layer name
+    info = info.replace(/layer(\s*)\'(\w+)\'([\w\s\S]*)/i, "$3");
+
+    // remove feature number
+    info = info.replace(/feature(\s*)(\w*)(\s*)(\:)([\w\s\S]*)/i, "$5");
+
+    // remove simple quotes
+    info = info.replace(/\'/g, "");
+
+    // replace the equal (=) with (;)
+    info = info.replace(/\=/g, ';');
+
+    var attrValuesString = info.split("\n");
+
+    var html = "";
+    var htmlHeader = "<table class=\"mapea-table\"><tbody><tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
+
+    for (var i = 0, ilen = attrValuesString.length; i < ilen; i++) {
+      var attrValueString = attrValuesString[i].trim();
+      var nextAttrValueString = attrValuesString[i] ? attrValuesString[i]
+        .trim() : "";
+      var attrValue = attrValueString.split(";");
+      var attr = attrValue[0].trim();
+      var value = "-";
+      if (attrValue.length > 1) {
+        value = attrValue[1].trim();
+        if (value.length === 0) {
+          value = "-";
+        }
       }
-      olMap.on('singleclick', this.buildUrl_, this);
-   };
 
-   /**
-    * This function builds the query URL and show results
-    *
-    * @private
-    * @function
-    * @param {ol.MapBrowserPointerEvent} evt - Browser point event
-    */
-   M.impl.control.GetFeatureInfo.prototype.buildUrl_ = function(evt) {
-      var olMap = this.facadeMap_.getMapImpl();
-      var viewResolution = olMap.getView().getResolution();
-      var srs = this.facadeMap_.getProjection().code;
-      var layerNamesUrls = [];
-      this.facadeMap_.getWMS().forEach(function(layer) {
-         var olLayer = layer.getImpl().getOL3Layer();
-         if (layer.isVisible() && layer.isQueryable() && !M.utils.isNullOrEmpty(olLayer)) {
-            let getFeatureInfoParams = {
-                  'INFO_FORMAT': this.userFormat,
-                  'FEATURE_COUNT': this.featureCount,
-               };
-            if (!/buffer/i.test(layer.url)) {
-               getFeatureInfoParams['Buffer'] = this.buffer;
-            }
-            var url = olLayer.getSource().getGetFeatureInfoUrl(evt.coordinate, viewResolution, srs, getFeatureInfoParams);
-            layerNamesUrls.push({
-               /** @type {String} */
-               'layer': layer.name,
-               /** @type {String} */
-               'url': url
-            });
-         }
-      }, this);
-      if (layerNamesUrls.length > 0) {
-         this.showInfoFromURL_(layerNamesUrls, evt.coordinate, olMap);
-      }
-      else {
-         M.dialog.info('No existen capas consultables');
-      }
-   };
-
-   /**
-    * This function remove the event singleclick to the specified map
-    *
-    * @private
-    * @function
-    */
-   M.impl.control.GetFeatureInfo.prototype.deleteOnClickEvent_ = function() {
-      var olMap = this.facadeMap_.getMapImpl();
-      olMap.un('singleclick', this.buildUrl_, this);
-   };
-
-   /**
-    * This function specifies whether the information is valid
-    *
-    * @param {string} info - Information to validate
-    * @param {string} formato - Specific format to validate
-    * @returns {boolean} res - Is valid or not format
-    * @private
-    * @function
-    */
-   M.impl.control.GetFeatureInfo.prototype.insert_ = function(info, formato) {
-      var res = false;
-      switch (formato) {
-         case "text/html": // ex
-            var infoContainer = document.createElement("div");
-            infoContainer.innerHTML = info;
-
-            // content
-            var content = "";
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('body'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('div'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('table'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('b'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('span'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('input'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('a'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('img'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('p'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('ul'), function(element) {
-               content += element.innerHTML.trim();
-            });
-            Array.prototype.forEach.call(infoContainer.querySelectorAll('li'), function(element) {
-               content += element.innerHTML.trim();
-            });
-
-            if ((content.length > 0) && !/WMS\s+server\s+error/i.test(info)) {
-               res = true;
-            }
-            break;
-         case "application/vnd.ogc.gml": // ol.format.GML (http://openlayers.org/en/v3.9.0/apidoc/ol.format.GML.html)
-            var formater = new ol.format.WFS();
-            var features = formater.readFeatures(info);
-            res = (features.length > 0);
-            break;
-         case "text/plain": // exp reg
-            if (!/returned\s+no\s+results/i.test(info) && !/features\s+were\s+found/i.test(info) && !/:$/i.test(info)) {
-               res = true;
-            }
-            break;
-      }
-      return res;
-   };
-
-   /**
-    * This function formats the response
-    *
-    * @param {string} info - Information to formatting
-    * @param {string} formato - Specific format
-    * @param {string} layername - Layer name
-    * @returns {string} information - Formatted information
-    * @private
-    * @function
-    */
-   M.impl.control.GetFeatureInfo.prototype.formatInfo_ = function(info, formato, layerName) {
-      var formatedInfo = null;
-      switch (formato) {
-         case "text/html": // ex
-            formatedInfo = info;
-            break;
-         case "application/vnd.ogc.gml": // ol.format.GML (http://openlayers.org/en/v3.9.0/apidoc/ol.format.GML.html)
-            // var formater = new ol.format.GML();
-            // var feature = formater.readFeatures(info)[0];
-            var formater = new ol.format.WFS();
-            var features = formater.readFeatures(info);
-            formatedInfo = "";
-            features.forEach(function(feature) {
-               var attr = feature.getKeys();
-               formatedInfo += "<div class=\"divinfo\">";
-               formatedInfo += "<table class=\"mapea-table\"><tbody><tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
-               for (var i = 0, ilen = attr.length; i < ilen; i++) {
-                  var attrName = attr[i];
-                  var attrValue = feature.get(attrName);
-
-                  formatedInfo += '<tr><td class="key"><b>';
-                  formatedInfo += M.utils.beautifyAttribute(attrName);
-                  formatedInfo += '</b></td><td class="value">';
-                  formatedInfo += attrValue;
-                  formatedInfo += "</td></tr>";
-               }
-               formatedInfo += "</tbody></table></div>";
-            });
-            break;
-         case "text/plain": // exp reg
-            if (regExs.gsResponse.test(info)) {
-               formatedInfo = this.txtToHtml_Geoserver_(info, layerName);
-            }
-            else {
-               formatedInfo = this.txtToHtml_Mapserver_(info, layerName);
-            }
-            break;
-      }
-      return formatedInfo;
-   };
-
-   /**
-    * This function indicates whether the format is accepted by the layer - Specific format text/html
-    *
-    * @param {string} info - Response to consult layer
-    * @param {string} formato - Specific format
-    * @returns {boolean} unsupported - It indicates whether the format is accepted
-    * @private
-    * @function
-    */
-   M.impl.control.GetFeatureInfo.prototype.unsupportedFormat_ = function(info, formato) {
-      var unsupported = false;
-      if (formato === "text/html") {
-         unsupported = regExs.msUnsupportedFormat.test(info);
-      }
-      return unsupported;
-   };
-
-   /**
-    * This function return formatted information. Specific Geoserver
-    *
-    * @private
-    * @function
-    * @param {string} info - Information to formatting
-    * @param {string} layername - Layer name
-    * @returns {string} html - Information formated
-    */
-   M.impl.control.GetFeatureInfo.prototype.txtToHtml_Geoserver_ = function(info, layerName) {
-      // get layer name from the header
-      // var layerName = info.replace(/[\w\s\S]*\:(\w*)\'\:[\s\S\w]*/i, "$1");
-
-      // remove header
-      info = info.replace(/[\w\s\S]*\'\:/i, "");
-
-      info = info.replace(/---(\-*)(\n+)---(\-*)/g, "#newfeature#");
-
-      var attrValuesString = info.split("\n");
-
-      var html = "<div class=\"divinfo\">";
-
-      // build the table
-      html += "<table class=\"mapea-table\"><tbody><tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
-
-      for (var i = 0, ilen = attrValuesString.length; i < ilen; i++) {
-         var attrValueString = attrValuesString[i].trim();
-         if (attrValueString.indexOf("=") != -1) {
-            var attrValue = attrValueString.split("=");
-            var attr = attrValue[0].trim();
-            var value = "-";
-            if (attrValue.length > 1) {
-               value = attrValue[1].trim();
-               if (value.length === 0 || value === "null") {
-                  value = "-";
-               }
-            }
-
-            if (regExs.gsGeometry.test(attr) === false) {
-               html += '<tr><td class="key"><b>';
-               html += M.utils.beautifyAttribute(attr);
-               html += '</b></td><td class="value">';
-               html += value;
-               html += "</td></tr>";
-            }
-         }
-         else if (regExs.gsNewFeature.test(attrValueString)) {
+      if (attr.length > 0) {
+        if (regExs.msNewFeature.test(attr)) {
+          if ((nextAttrValueString.length > 0) && !regExs.msNewFeature.test(nextAttrValueString)) {
             // set new header
-            html += "<tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
-         }
+            html += "<tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td><td></td></tr>";
+          }
+        }
+        else {
+          html += '<tr><td class="key"><b>';
+          html += M.utils.beautifyAttribute(attr);
+          html += '</b></td><td class="value">';
+          html += value;
+          html += "</td></tr>";
+        }
       }
+    }
 
-      html += "</tbody></table></div>";
+    if (html.length > 0) {
+      html = htmlHeader + html + "</tbody></table>";
+    }
 
-      return html;
-   };
+    return html;
+  };
 
-   /**
-    * This function return formatted information. Specific Mapserver
-    *
-    * @private
-    * @function
-    * @param {string} info - Information to formatting
-    * @returns {string} html - Information formated
-    */
-   M.impl.control.GetFeatureInfo.prototype.txtToHtml_Mapserver_ = function(info) {
-      // remove header
-      info = info.replace(/[\w\s\S]*(layer)/i, "$1");
+  /**
+   * This function displays information in a popup
+   *
+   * @private
+   * @function
+   * @param {array<object>} layerNamesUrls - Consulted layers
+   * @param {array} coordinate - Coordinate position onClick
+   * @param {olMap} olMap - Map
 
-      // get layer name
-      var layerName = info.replace(/layer(\s*)\'(\w+)\'[\w\s\S]*/i, "$2");
-
-      // remove layer name
-      info = info.replace(/layer(\s*)\'(\w+)\'([\w\s\S]*)/i, "$3");
-
-      // remove feature number
-      info = info.replace(/feature(\s*)(\w*)(\s*)(\:)([\w\s\S]*)/i, "$5");
-
-      // remove simple quotes
-      info = info.replace(/\'/g, "");
-
-      // replace the equal (=) with (;)
-      info = info.replace(/\=/g, ';');
-
-      var attrValuesString = info.split("\n");
-
-      var html = "";
-      var htmlHeader = "<table class=\"mapea-table\"><tbody><tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td></tr>";
-
-      for (var i = 0, ilen = attrValuesString.length; i < ilen; i++) {
-         var attrValueString = attrValuesString[i].trim();
-         var nextAttrValueString = attrValuesString[i] ? attrValuesString[i]
-            .trim() : "";
-         var attrValue = attrValueString.split(";");
-         var attr = attrValue[0].trim();
-         var value = "-";
-         if (attrValue.length > 1) {
-            value = attrValue[1].trim();
-            if (value.length === 0) {
-               value = "-";
-            }
-         }
-
-         if (attr.length > 0) {
-            if (regExs.msNewFeature.test(attr)) {
-               if ((nextAttrValueString.length > 0) && !regExs.msNewFeature.test(nextAttrValueString)) {
-                  // set new header
-                  html += "<tr><td class=\"header\" colspan=\"3\">" + M.utils.beautifyAttribute(layerName) + "</td><td></td></tr>";
-               }
-            }
-            else {
-               html += '<tr><td class="key"><b>';
-               html += M.utils.beautifyAttribute(attr);
-               html += '</b></td><td class="value">';
-               html += value;
-               html += "</td></tr>";
-            }
-         }
+   */
+  M.impl.control.GetFeatureInfo.prototype.showInfoFromURL_ = function (layerNamesUrls,
+    coordinate, olMap) {
+    var infos = [];
+    var formato = String(this.userFormat);
+    var contFull = 0;
+    var this_ = this;
+    var loadingInfoTab;
+    var popup;
+    M.template.compile(M.control.GetFeatureInfo.POPUP_TEMPLATE, {
+      'jsonp': true,
+      'vars': {
+        'info': M.impl.control.GetFeatureInfo.LOADING_MESSAGE
+      },
+      'parseToHtml': false
+    }).then(function (htmlAsText) {
+      popup = this_.facadeMap_.getPopup();
+      loadingInfoTab = {
+        'icon': 'g-cartografia-info',
+        'title': M.control.GetFeatureInfo.POPUP_TITLE,
+        'content': htmlAsText
+      };
+      if (M.utils.isNullOrEmpty(popup)) {
+        popup = new M.Popup();
+        popup.addTab(loadingInfoTab);
+        this_.facadeMap_.addPopup(popup, coordinate);
       }
-
-      if (html.length > 0) {
-         html = htmlHeader + html + "</tbody></table>";
+      else {
+        // removes popup if all contents are getfeatureinfo
+        var hasExternalContent = popup.getTabs().some(function (tab) {
+          return (tab['title'] !== M.control.GetFeatureInfo.POPUP_TITLE);
+        });
+        if (!hasExternalContent) {
+          this_.facadeMap_.removePopup();
+          popup = new M.Popup();
+          popup.addTab(loadingInfoTab);
+          this_.facadeMap_.addPopup(popup, coordinate);
+        }
+        else {
+          popup.addTab(loadingInfoTab);
+        }
       }
-
-      return html;
-   };
-
-   /**
-    * This function displays information in a popup
-    *
-    * @private
-    * @function
-    * @param {array<object>} layerNamesUrls - Consulted layers
-    * @param {array} coordinate - Coordinate position onClick
-    * @param {olMap} olMap - Map
-
-    */
-   M.impl.control.GetFeatureInfo.prototype.showInfoFromURL_ = function(layerNamesUrls,
-      coordinate, olMap) {
-      var infos = [];
-      var formato = String(this.userFormat);
-      var contFull = 0;
-      var this_ = this;
-      var loadingInfoTab;
-      var popup;
-      M.template.compile(M.control.GetFeatureInfo.POPUP_TEMPLATE, {
-         'jsonp': true,
-         'vars': {
-            'info': M.impl.control.GetFeatureInfo.LOADING_MESSAGE
-         },
-         'parseToHtml': false
-      }).then(function(htmlAsText) {
-         popup = this_.facadeMap_.getPopup();
-         loadingInfoTab = {
-            'icon': 'g-cartografia-info',
-            'title': M.control.GetFeatureInfo.POPUP_TITLE,
-            'content': htmlAsText
-         };
-         if (M.utils.isNullOrEmpty(popup)) {
-            popup = new M.Popup();
-            popup.addTab(loadingInfoTab);
-            this_.facadeMap_.addPopup(popup, coordinate);
-         }
-         else {
-            // removes popup if all contents are getfeatureinfo
-            var hasExternalContent = popup.getTabs().some(function(tab) {
-               return (tab['title'] !== M.control.GetFeatureInfo.POPUP_TITLE);
+    });
+    layerNamesUrls.forEach(function (layerNameUrl) {
+      var url = layerNameUrl['url'];
+      var layerName = layerNameUrl['layer'];
+      M.remote.get(url).then(function (response) {
+        popup = this_.facadeMap_.getPopup();
+        if ((response.code === 200) && (response.error === false)) {
+          var info = response.text;
+          if (this_.insert_(info, formato) === true) {
+            var formatedInfo = this_.formatInfo_(info, formato, layerName);
+            infos.push(formatedInfo);
+          }
+          else if (this_.unsupportedFormat_(info, formato)) {
+            infos.push('La capa <b>' + layerName + '</b> no soporta el formato <i>' + formato + '</i>');
+          }
+        }
+        if (layerNamesUrls.length === ++contFull && !M.utils.isNullOrEmpty(popup)) {
+          popup.removeTab(loadingInfoTab);
+          if (infos.join('') === "") {
+            popup.addTab({
+              'icon': 'g-cartografia-info',
+              'title': M.control.GetFeatureInfo.POPUP_TITLE,
+              'content': 'No hay información asociada.'
             });
-            if (!hasExternalContent) {
-               this_.facadeMap_.removePopup();
-               popup = new M.Popup();
-               popup.addTab(loadingInfoTab);
-               this_.facadeMap_.addPopup(popup, coordinate);
-            }
-            else {
-               popup.addTab(loadingInfoTab);
-            }
-         }
+          }
+          else {
+            popup.addTab({
+              'icon': 'g-cartografia-info',
+              'title': M.control.GetFeatureInfo.POPUP_TITLE,
+              'content': infos.join('')
+            });
+          }
+        }
       });
-      layerNamesUrls.forEach(function(layerNameUrl) {
-         var url = layerNameUrl['url'];
-         var layerName = layerNameUrl['layer'];
-         M.remote.get(url).then(function(response) {
-            popup = this_.facadeMap_.getPopup();
-            if ((response.code === 200) && (response.error === false)) {
-               var info = response.text;
-               if (this_.insert_(info, formato) === true) {
-                  var formatedInfo = this_.formatInfo_(info, formato, layerName);
-                  infos.push(formatedInfo);
-               }
-               else if (this_.unsupportedFormat_(info, formato)) {
-                  infos.push('La capa <b>' + layerName + '</b> no soporta el formato <i>' + formato + '</i>');
-               }
-            }
-            if (layerNamesUrls.length === ++contFull) {
-               popup.removeTab(loadingInfoTab);
-               if (infos.join('') === "") {
-                  popup.addTab({
-                     'icon': 'g-cartografia-info',
-                     'title': M.control.GetFeatureInfo.POPUP_TITLE,
-                     'content': 'No hay información asociada.'
-                  });
-               }
-               else {
-                  popup.addTab({
-                     'icon': 'g-cartografia-info',
-                     'title': M.control.GetFeatureInfo.POPUP_TITLE,
-                     'content': infos.join('')
-                  });
-               }
-            }
-         });
-      });
-   };
+    });
+  };
 
-   /**
-    * Loading message
-    * @const
-    * @type {string}
-    * @public
-    * @api stable
-    */
-   M.impl.control.GetFeatureInfo.LOADING_MESSAGE = 'Obteniendo información...';
+  /**
+   * Loading message
+   * @const
+   * @type {string}
+   * @public
+   * @api stable
+   */
+  M.impl.control.GetFeatureInfo.LOADING_MESSAGE = 'Obteniendo información...';
 })();

--- a/mapea-js/src/impl/ol3/js/layers/osm.js
+++ b/mapea-js/src/impl/ol3/js/layers/osm.js
@@ -18,6 +18,9 @@ goog.require('ol.source.OSM');
    * @api stable
    */
   M.impl.layer.OSM = (function (userParameters, options) {
+    // check for null options
+    options = options || {};
+
     /**
      * Layer resolutions
      * @private

--- a/mapea-js/src/impl/ol3/js/layers/wmc.js
+++ b/mapea-js/src/impl/ol3/js/layers/wmc.js
@@ -4,9 +4,7 @@ goog.require('M.utils');
 goog.require('M.exception');
 goog.require('M.impl.Layer');
 goog.require('M.impl.format.WMC.v110');
-
-goog.require('ol.Extent');
-
+goog.require('M.evt.EventsManager');
 
 (function () {
   /**
@@ -92,36 +90,36 @@ goog.require('ol.Extent');
       this.selected = true;
 
       // loads the layers from this WMC if it is not cached
-      var this_ = this;
       this.loadContextPromise = new Promise(function (success, fail) {
-        M.remote.get(this_.url).then(function (response) {
+        M.remote.get(this.url).then(function (response) {
           var proj;
-          if (this_.map._defaultProj === false) {
-            proj = this_.map.getProjection().code;
+          if (this.map._defaultProj === false) {
+            proj = this.map.getProjection().code;
           }
           var wmcDocument = response.xml;
           var formater = new M.impl.format.WMC({
             'projection': proj
           });
           var context = formater.readFromDocument(wmcDocument);
-          success.call(this_, context);
-        });
-      });
+          success.call(this, context);
+        }.bind(this));
+      }.bind(this));
       this.loadContextPromise.then(function (context) {
         // set projection with the wmc
-        if (this_.map._defaultProj) {
+        if (this.map._defaultProj) {
           var olproj = ol.proj.get(context.projection);
-          this_.map.setProjection({
+          this.map.setProjection({
             "code": olproj.getCode(),
             "units": olproj.getUnits()
           }, true);
         }
         // load layers
-        this_.loadLayers(context);
+        this.loadLayers(context);
         if (!M.utils.isNullOrEmpty(bbox)) {
-          this_.map.setBbox(bbox);
+          this.map.setBbox(bbox);
         }
-      });
+        this.map.fire(M.evt.CHANGE_WMC, this);
+      }.bind(this));
     }
   };
 

--- a/mapea-js/src/impl/ol3/js/layers/wms.js
+++ b/mapea-js/src/impl/ol3/js/layers/wms.js
@@ -256,9 +256,9 @@ goog.require('ol.extent');
         }
         else {
           newSource = new ol.source.ImageWMS({
-            url: this_.url,
             params: layerParams,
-            resolutions: resolutions
+            resolutions: resolutions,
+            projection: this.map.getProjection().code
           });
         }
         this_.ol3Layer.setSource(newSource);
@@ -335,13 +335,14 @@ goog.require('ol.extent');
           visible: this.visibility && (this.options.visibility !== false),
           source: new ol.source.ImageWMS({
             url: this.url,
-            params: layerParams
+            params: layerParams,
+            resolutions: resolutions,
+            projection: this.map.getProjection().code
           }),
           extent: olExtent,
           minResolution: this.options.minResolution,
           maxResolution: this.options.maxResolution,
-          opacity: this.opacity_,
-          zIndex: this.zIndex_
+          opacity: this.opacity_
         });
       }
       // keeps z-index values before ol resets


### PR DESCRIPTION
## Versión 4.0.3 del 10/03/2017 rectificada sin la migración de OL

Se lleva a cabo la actualización a la versión 4.0.3 con las siguientes correcciones:

- Se solventa el error que impedía poner en el constructor del mapa el parámetro layers=OSM
- Se implementa el evento CHANGED_WMC al cambiar de WMC #80 
- Se comprueba la existencia del popup dentro del control getfeatureinfo antes de usarlo
- Control de errores al eliminar el panel del control #93