### PR TITLE
Correcciones sobre la entrega 4.0.4

### DIFF
--- a/mapea-js/src/impl/ol/js/map/map.js
+++ b/mapea-js/src/impl/ol/js/map/map.js
@@ -1196,7 +1196,15 @@ goog.require('ol.Map');
    * @api stable
    */
   M.impl.Map.prototype.getZoom = function () {
-    var zoom = this.getMapImpl().getView().getZoom();
+    let resolution = this.getMapImpl().getView().getResolution();
+    let resolutions = this.getResolutions();
+    let zoom = null;
+    for (var i = 0, ilen = resolutions.length; i < ilen; i++) {
+      if (resolutions[i] <= resolution) {
+        zoom = i;
+        break;
+      }
+    }
     return zoom;
   };
 

--- a/mapea-js/src/plugins/wfstcontrols/impl/ol/js/clearfeature.js
+++ b/mapea-js/src/plugins/wfstcontrols/impl/ol/js/clearfeature.js
@@ -67,7 +67,7 @@ goog.provide('P.impl.control.ClearFeature');
          editattributeCtrl.getImpl().editedFeature = null;
          editattributeCtrl.deactivate();
       }
-      this.layer_.getImpl().refresh();
+      this.layer_.getImpl().refresh(true);
    };
 
    /**


### PR DESCRIPTION
## Se realizan las siguientes correcciones sobre la entrega 4.0.4:

- Se corrige el comportamiento de los controles WFS-T forzando el refresco de la capa.
- Se corrige el método `getZoom` sobre la implementación de ol para evitar obtener zoom con decimales.