### PR TITLE
El protocolo de algunos parametros se lee del location

### DIFF
--- a/mapea-js/src/configuration.js
+++ b/mapea-js/src/configuration.js
@@ -29,7 +29,7 @@
     * @public
     * @api stable
     */
-   M.config('PROXY_URL', '${mapea.proxy.url}');
+   M.config('PROXY_URL', location.protocol + '${mapea.proxy.url}');
 
    /**
     * The path to the Mapea proxy to send
@@ -39,7 +39,7 @@
     * @public
     * @api stable
     */
-   M.config('PROXY_POST_URL', '${mapea.proxy_post.url}');
+   M.config('PROXY_POST_URL', location.protocol + '${mapea.proxy_post.url}');
 
    /**
     * The path to the Mapea templates
@@ -57,7 +57,7 @@
     * @public
     * @api stable
     */
-   M.config('THEME_URL', '${mapea.theme.url}');
+   M.config('THEME_URL', location.protocol + '${mapea.theme.url}');
 
    /**
     * The Geosearch URL

--- a/mapea-parent/src/main/filters/mapea-desarrollo.properties
+++ b/mapea-parent/src/main/filters/mapea-desarrollo.properties
@@ -1,9 +1,9 @@
 mobile.width=768
 mapea.url=https://sigc.desarrollo.guadaltel.es/mapea
-mapea.proxy.url=https://sigc.desarrollo.guadaltel.es/mapea/api/proxy
-mapea.proxy_post.url=https://sigc.desarrollo.guadaltel.es/mapea/proxyPost
+mapea.proxy.url=//sigc.desarrollo.guadaltel.es/mapea/api/proxy
+mapea.proxy_post.url=//sigc.desarrollo.guadaltel.es/mapea/proxyPost
 mapea.templates.path=/files/templates/
-mapea.theme.url=https://sigc.desarrollo.guadaltel.es/mapea/assets/
+mapea.theme.url=//sigc.desarrollo.guadaltel.es/mapea/assets/
 geosearch.url=http://geobusquedas-sigc.juntadeandalucia.es
 geosearch.core=sigc
 geosearch.handler=/search?

--- a/mapea-parent/src/main/filters/mapea-local.properties
+++ b/mapea-parent/src/main/filters/mapea-local.properties
@@ -1,9 +1,9 @@
 mobile.width=768
 mapea.url=http://localhost:3030/mapea
-mapea.proxy.url=http://localhost:3030/mapea/api/proxy
-mapea.proxy_post.url=http://localhost:3030/mapea/proxyPost
+mapea.proxy.url=//localhost:3030/mapea/api/proxy
+mapea.proxy_post.url=//localhost:3030/mapea/proxyPost
 mapea.templates.path=/files/templates/
-mapea.theme.url=http://localhost:3030/mapea/assets/
+mapea.theme.url=//localhost:3030/mapea/assets/
 geosearch.url=http://geobusquedas-sigc.juntadeandalucia.es
 geosearch.core=sigc
 geosearch.handler=/search?

--- a/mapea-parent/src/main/filters/mapea-preproduccion.properties
+++ b/mapea-parent/src/main/filters/mapea-preproduccion.properties
@@ -1,9 +1,9 @@
 mobile.width=768
 mapea.url=http://$URL_MAPEA4
-mapea.proxy.url=http://$URL_MAPEA4/api/proxy
-mapea.proxy_post.url=http://$URL_MAPEA4/proxyPost
+mapea.proxy.url=//$URL_MAPEA4/api/proxy
+mapea.proxy_post.url=//$URL_MAPEA4/proxyPost
 mapea.templates.path=/files/templates/
-mapea.theme.url=http://$URL_MAPEA4/assets/
+mapea.theme.url=//$URL_MAPEA4/assets/
 geosearch.url=http://geobusquedas-sigc.juntadeandalucia.es
 geosearch.core=sigc
 geosearch.handler=/search?

--- a/mapea-parent/src/main/filters/mapea-produccion.properties
+++ b/mapea-parent/src/main/filters/mapea-produccion.properties
@@ -1,9 +1,9 @@
 mobile.width=768
 mapea.url=http://$URL_MAPEA4
-mapea.proxy.url=http://$URL_MAPEA4/api/proxy
-mapea.proxy_post.url=http://$URL_MAPEA4/proxyPost
+mapea.proxy.url=//$URL_MAPEA4/api/proxy
+mapea.proxy_post.url=//$URL_MAPEA4/proxyPost
 mapea.templates.path=/files/templates/
-mapea.theme.url=http://$URL_MAPEA4/assets/
+mapea.theme.url=//$URL_MAPEA4/assets/
 geosearch.url=http://geobusquedas-sigc.juntadeandalucia.es
 geosearch.core=sigc
 geosearch.handler=/search?

--- a/mapea-parent/src/main/filters/mapea-pruebas.properties
+++ b/mapea-parent/src/main/filters/mapea-pruebas.properties
@@ -1,9 +1,9 @@
 mobile.width=768
 mapea.url=http://$URL_MAPEA4
-mapea.proxy.url=http://$URL_MAPEA4/api/proxy
-mapea.proxy_post.url=http://$URL_MAPEA4/proxyPost
+mapea.proxy.url=//$URL_MAPEA4/api/proxy
+mapea.proxy_post.url=//$URL_MAPEA4/proxyPost
 mapea.templates.path=/files/templates/
-mapea.theme.url=http://$URL_MAPEA4/assets/
+mapea.theme.url=//$URL_MAPEA4/assets/
 geosearch.url=http://geobusquedas-sigc.juntadeandalucia.es
 geosearch.core=sigc
 geosearch.handler=/search?


### PR DESCRIPTION
El fichero configuration.js ya no especifica el protocolo en las urls de los proxys ni del theme, sino que lee el que haya en _location.protocol_, adaptándose así al que se esté usando en el momento de su llamada.

Los perfiles de compilación, por tanto, eliminan el protocolo de los valores de dichos parámetros.