### PR TITLE
Solucion de bugs en grunt-task install libraries

### DIFF
--- a/mapea-js/grunt-tasks/install-libraries.js
+++ b/mapea-js/grunt-tasks/install-libraries.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
          var implRootDir = path.join(ROOT, impl.dir);
 
          // npm install
-         exec('npm install', {
+         exec('../../node/node ../../node/npm/bin/npm-cli.js install', {
             cwd: implRootDir
          }, function(err, stdout, stderr) {
             console.log(stdout);


### PR DESCRIPTION
Anteriormente una de las tareas de grunt era descargar node y npm de una versión concreta para compilar. El problema era que aunque se descargaba esas versiones y se instalaban se acababa usando el que tuviera la máquina.
Se ha solucionado poniendo el path correcto.