### PR TITLE
Issue #179

### DIFF
--- a/mapea-js/src/facade/js/style/styleline.js
+++ b/mapea-js/src/facade/js/style/styleline.js
@@ -23,6 +23,7 @@ goog.require('M.style.Simple');
       options = M.style.Line.DEFAULT_NULL;
     }
 
+    options = M.utils.extends({}, options);
     let impl = new M.impl.style.Line(options);
     goog.base(this, options, impl);
   });

--- a/mapea-js/src/facade/js/style/stylepoint.js
+++ b/mapea-js/src/facade/js/style/stylepoint.js
@@ -20,8 +20,9 @@ goog.require('M.style.Simple');
       options = M.style.Point.DEFAULT_NULL;
     }
     else {
-      M.utils.extends(options, M.style.Point.DEFAULT);
+      options = M.utils.extends(options, M.style.Point.DEFAULT);
     }
+    options = M.utils.extends({}, options);
     var impl = new M.impl.style.Point(options);
     goog.base(this, options, impl);
   });

--- a/mapea-js/src/facade/js/style/stylepolygon.js
+++ b/mapea-js/src/facade/js/style/stylepolygon.js
@@ -22,6 +22,7 @@ goog.require('M.style.Simple');
       options = M.style.Polygon.DEFAULT_NULL;
     }
 
+    options = M.utils.extends({}, options);
     var impl = new M.impl.style.Polygon(options);
     goog.base(this, options, impl);
   });


### PR DESCRIPTION
En el constructor de los estilos simples se clonan las instancias del
options que le pasa el usuario por parametro para evitar que 2 o más
estilos compartan las mismas instancias de opciones.