### PR TITLE
Solución de varios errores

### DIFF
--- a/mapea-js/src/facade/assets/css/controls/layerswitcher.css
+++ b/mapea-js/src/facade/assets/css/controls/layerswitcher.css
@@ -267,7 +267,7 @@
     margin-left: 0;
     width: 100vw;
     height: 100vh;
-    /*position: fixed;*/
+    position: fixed;
     top: 0;
     left: 0;
     margin: 0;

--- a/mapea-js/src/facade/js/layers/vector.js
+++ b/mapea-js/src/facade/js/layers/vector.js
@@ -155,19 +155,19 @@ goog.require('M.exception');
    */
   M.layer.Vector.prototype.redraw = function() {
     this.getImpl().redraw();
-    if (!M.utils.isNullOrEmpty(this.getStyle())) {
-      let style = this.getStyle();
-      if (!(style instanceof M.style.Cluster)) {
-        style.refresh();
-      }
-      else {
-        let oldStyle = style.getOldStyle();
-        if (!M.utils.isNullOrEmpty(oldStyle)) {
-          oldStyle.refresh(this);
-        }
-
-      }
-    }
+    // if (!M.utils.isNullOrEmpty(this.getStyle())) {
+    //   let style = this.getStyle();
+    //   if (!(style instanceof M.style.Cluster)) {
+    //     style.refresh();
+    //   }
+    //   else {
+    //     let oldStyle = style.getOldStyle();
+    //     if (!M.utils.isNullOrEmpty(oldStyle)) {
+    //       oldStyle.refresh(this);
+    //     }
+    //
+    //   }
+    // }
   };
 
   /**

--- a/mapea-js/src/facade/js/style/stylecluster.js
+++ b/mapea-js/src/facade/js/style/stylecluster.js
@@ -199,8 +199,9 @@ goog.require('M.style.Composite');
    */
   M.style.Cluster.prototype.refresh = function() {
     if (!M.utils.isNullOrEmpty(this.layer_)) {
+      let layer = this.layer_;
       this.unapply(this.layer_);
-      this.apply(this.layer_);
+      this.apply(layer);
       this.updateCanvas();
     }
   };

--- a/mapea-js/src/facade/js/style/stylecluster.js
+++ b/mapea-js/src/facade/js/style/stylecluster.js
@@ -46,7 +46,7 @@ goog.require('M.style.Composite');
     if (!M.utils.isNullOrEmpty(this.layer_)) {
       this.unapplySoft(this.layer_);
     }
-    goog.base(this, 'add', styles);
+    return goog.base(this, 'add', styles);
   };
 
   /**

--- a/mapea-js/src/facade/js/style/stylecomposite.js
+++ b/mapea-js/src/facade/js/style/stylecomposite.js
@@ -33,7 +33,8 @@ goog.require('M.Style');
   M.style.Composite.prototype.apply = function(layer) {
     this.layer_ = layer;
     if (!M.utils.isNullOrEmpty(layer)) {
-      this.oldStyle_ = layer.getStyle();
+      let style = layer.getStyle();
+      this.oldStyle_ = style instanceof M.style.Cluster ? style.getOldStyle() : style;
       this.updateInternal_(layer);
     }
   };
@@ -171,7 +172,8 @@ goog.require('M.Style');
     styles.forEach(style => {
       if (style instanceof M.style.Composite) {
         style.applyInternal_(layer);
-      } else if (style instanceof M.Style) {
+      }
+      else if (style instanceof M.Style) {
         style.apply(layer, true);
       }
     });

--- a/mapea-js/src/impl/ol/js/layers/vector.js
+++ b/mapea-js/src/impl/ol/js/layers/vector.js
@@ -218,16 +218,26 @@ goog.require('M.impl.renderutils');
   M.impl.layer.Vector.prototype.redraw = function() {
     let olLayer = this.getOL3Layer();
     if (!M.utils.isNullOrEmpty(olLayer)) {
+      let style = this.facadeVector_.getStyle();
       let olSource = olLayer.getSource();
       if (olSource instanceof ol.source.Cluster) {
         olSource = olSource.getSource();
       }
+
+      if (style instanceof M.style.Cluster) {
+        style.getImpl().deactivateChangeEvent();
+      }
+
       // remove all features from ol vector
       let olFeatures = [...olSource.getFeatures()];
       olFeatures.forEach(olSource.removeFeature, olSource);
 
       let features = this.facadeVector_.getFeatures();
       olSource.addFeatures(features.map(M.impl.Feature.facade2OLFeature));
+
+      if (style instanceof M.style.Cluster) {
+        style.getImpl().activateChangeEvent();
+      }
     }
   };
 

--- a/mapea-js/src/impl/ol/js/styles/stylecluster.js
+++ b/mapea-js/src/impl/ol/js/styles/stylecluster.js
@@ -476,13 +476,13 @@ goog.require('ol.geom.convexhull');
   M.impl.style.Cluster.prototype.unapply = function() {
     if (!M.utils.isNullOrEmpty(this.clusterLayer_)) {
       let clusterSource = this.clusterLayer_.getSource();
-      clusterSource.getSource().un(ol.events.EventType.CHANGE, ol.source.Cluster.prototype.refresh_, clusterSource);
       this.layer_.getImpl().setOL3Layer(this.oldOLLayer_);
       this.removeCoverInteraction_();
       this.removeSelectInteraction_();
       this.clearConvexHull();
       this.layer_.getImpl().getMap().getMapImpl().getView().un('change:resolution', this.clearConvexHull, this);
       this.layer_.redraw();
+      clusterSource.getSource().un(ol.events.EventType.CHANGE, ol.source.Cluster.prototype.refresh_, clusterSource);
     }
     else {
       if (!M.utils.isNullOrEmpty(this.layer_)) {


### PR DESCRIPTION
- Se soluciona error de estilo en el fichero layerswitcher.css para una visualización correcta en modo móvil.
- Se soluciona que M.style.Cluster al hacer uso de la función .add de M.style.Composite devuelva su instancia.
- Se corrigen problemas de rendimiento cuando se combinan cluster con otros estilos o con filtros.