### PR TITLE
Se corrige error de bind con el evento change:view

### DIFF
--- a/mapea-js/src/impl/ol/js/style/Cluster.js
+++ b/mapea-js/src/impl/ol/js/style/Cluster.js
@@ -298,7 +298,7 @@ class Cluster extends Style {
     });
     this.selectClusterInteraction_.on('select', this.selectClusterFeature_.bind(this), this);
     map.getMapImpl().addInteraction(this.selectClusterInteraction_);
-    map.getMapImpl().on('change:view', () => this.selectClusterInteraction_.refreshViewEvents().bind(this));
+    map.getMapImpl().on('change:view', evt => this.selectClusterInteraction_.refreshViewEvents(evt));
   }
 
   /**


### PR DESCRIPTION
Se elimina error de cambio de proyección cuando se tiene una capa clusterizada:

**Ejemplo**: http://jsfiddle.net/1mjtsb6z/3/