### PR TITLE
Bug en los estilos del polígono con patrón de imágenes

### DIFF
--- a/mapea-js/src/impl/ol/js/style/Polygon.js
+++ b/mapea-js/src/impl/ol/js/style/Polygon.js
@@ -128,7 +128,7 @@ class Polygon extends Simple {
 
             size: Simple.getValue(options.fill.pattern.size, featureVariable, this.layer_),
             spacing: Simple.getValue(options.fill.pattern.spacing, featureVariable, this.layer_),
-            image: (Simple.getValue(options.fill.pattern.name, featureVariable, this.layer_) === 'Image') ?
+            image: (Simple.getValue(options.fill.pattern.name, featureVariable, this.layer_) === 'IMAGE') ?
               new OLStyleIcon({
                 src: Simple.getValue(options.fill.pattern.src, featureVariable, this.layer_),
               }) : undefined,


### PR DESCRIPTION
De acuerdo al archivo facade/js/style/Pattern.js, la constante de para crear un estilo con un patrón con imágenes corresponde con 
`M.style.pattern.IMAGE = 'IMAGE'`

En cambio, a la hora de leerlo al aplicarle el estilo, lo compara con 'Image'.
`(Simple.getValue(options.fill.pattern.name, featureVariable, this.layer_) === 'Image')`

Haciendo que si le añades el M.style.pattern.IMAGE a la hora de crear el estilo, no llegue a funcionar.